### PR TITLE
마이너한 버그 픽스 및 코드 정리

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/DeepLinkInfo.kt
+++ b/app/src/main/java/com/zion830/threedollars/DeepLinkInfo.kt
@@ -19,7 +19,11 @@ enum class DeepLinkInfo(@StringRes val hostStringResId: Int) {
 
     DETAIL(R.string.scheme_host_kakao_link) {
         override fun getIntent(context: Context, deepLinkUri: Uri): Intent {
-            return SplashActivity.getIntent(context,deepLinkUri,deepLinkUri.getQueryParameter(context.getString(R.string.scheme_host_kakao_link_store_type)))
+            return SplashActivity.getIntent(
+                context,
+                deepLinkUri,
+                deepLinkUri.getQueryParameter(context.getString(R.string.scheme_host_kakao_link_store_type))
+            )
         }
     };
 

--- a/app/src/main/java/com/zion830/threedollars/customview/NaverMapFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/customview/NaverMapFragment.kt
@@ -148,10 +148,10 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
                 }
                 this.icon = if (item is StoreInfo) {
                     OverlayImage.fromResource(drawableRes)
-                } else{
-                    if((item as BossNearStoreResponse.BossNearStoreModel).openStatus?.status == "CLOSED"){
+                } else {
+                    if ((item as BossNearStoreResponse.BossNearStoreModel).openStatus?.status == "CLOSED") {
                         OverlayImage.fromResource(R.drawable.ic_food_truck_off)
-                    } else{
+                    } else {
                         OverlayImage.fromResource(drawableRes)
                     }
                 }

--- a/app/src/main/java/com/zion830/threedollars/datasource/PopupDataSource.kt
+++ b/app/src/main/java/com/zion830/threedollars/datasource/PopupDataSource.kt
@@ -4,5 +4,5 @@ import com.zion830.threedollars.datasource.model.v2.response.PopupsResponse
 import retrofit2.Response
 
 interface PopupDataSource {
-    suspend fun getPopups(position: String) : Response<PopupsResponse>
+    suspend fun getPopups(position: String): Response<PopupsResponse>
 }

--- a/app/src/main/java/com/zion830/threedollars/datasource/model/v2/response/store/BossCategoriesResponse.kt
+++ b/app/src/main/java/com/zion830/threedollars/datasource/model/v2/response/store/BossCategoriesResponse.kt
@@ -2,6 +2,7 @@ package com.zion830.threedollars.datasource.model.v2.response.store
 
 
 import com.google.gson.annotations.SerializedName
+import com.zion830.threedollars.BuildConfig
 
 data class BossCategoriesResponse(
     @SerializedName("data")
@@ -13,12 +14,16 @@ data class BossCategoriesResponse(
 ) {
     data class BossCategoriesModel(
         @SerializedName("categoryId")
-        val categoryId: String? = "628a42eb899ec19e976e54d7",
+        val categoryId: String? = if (BuildConfig.DEBUG) {
+            "622b7d0105ecea5baeafd245"
+        } else {
+            "628a42eb899ec19e976e54d7"
+        },
         @SerializedName("name")
         val name: String = "한식",
         @SerializedName("imageUrl")
         val imageUrl: String? = "https://storage.threedollars.co.kr/menu/icon_menu_3x_bab.png",
         @SerializedName("description")
-        val description : String = "한식 만나기 30초 전"
+        val description: String = "한식 만나기 30초 전"
     )
 }

--- a/app/src/main/java/com/zion830/threedollars/ui/MyPageSettingFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/MyPageSettingFragment.kt
@@ -99,7 +99,7 @@ class MyPageSettingFragment :
             }
         }
 
-        viewModel.userInfo.observe(viewLifecycleOwner){
+        viewModel.userInfo.observe(viewLifecycleOwner) {
             binding.pushSwitchButton.isChecked = it.data.device?.isSetupNotification == true
         }
     }

--- a/app/src/main/java/com/zion830/threedollars/ui/addstore/adapter/MenuRecyclerAdapter.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/addstore/adapter/MenuRecyclerAdapter.kt
@@ -5,6 +5,4 @@ import com.zion830.threedollars.databinding.ItemMenuBinding
 import com.zion830.threedollars.datasource.model.v2.request.MyMenu
 import zion830.com.common.base.BaseRecyclerView
 
-class MenuRecyclerAdapter : BaseRecyclerView<ItemMenuBinding, MyMenu>(R.layout.item_menu) {
-
-}
+class MenuRecyclerAdapter : BaseRecyclerView<ItemMenuBinding, MyMenu>(R.layout.item_menu)

--- a/app/src/main/java/com/zion830/threedollars/ui/category/SortType.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/category/SortType.kt
@@ -1,5 +1,5 @@
 package com.zion830.threedollars.ui.category
 
 enum class SortType {
-    DISTANCE, RATING , REVIEW
+    DISTANCE, RATING, REVIEW
 }

--- a/app/src/main/java/com/zion830/threedollars/ui/category/StoreDetailViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/category/StoreDetailViewModel.kt
@@ -33,7 +33,7 @@ import javax.inject.Inject
 
 // TODO : Edit 로직 분리 필요
 @HiltViewModel
-class StoreDetailViewModel @Inject constructor(private val repository : StoreDataSource) : BaseViewModel() {
+class StoreDetailViewModel @Inject constructor(private val repository: StoreDataSource) : BaseViewModel() {
 
     private val _storeInfo: MutableLiveData<StoreDetail?> = MutableLiveData()
     val storeInfo: LiveData<StoreDetail?>

--- a/app/src/main/java/com/zion830/threedollars/ui/category/StreetByMenuFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/category/StreetByMenuFragment.kt
@@ -28,7 +28,7 @@ import zion830.com.common.listener.OnItemClickListener
 
 @AndroidEntryPoint
 class StreetByMenuFragment :
-    BaseFragment<FragmentStreetByMenuBinding, StreetStoreByMenuViewModel>(R.layout.fragment_street_by_menu){
+    BaseFragment<FragmentStreetByMenuBinding, StreetStoreByMenuViewModel>(R.layout.fragment_street_by_menu) {
 
     override val viewModel: StreetStoreByMenuViewModel by activityViewModels()
 

--- a/app/src/main/java/com/zion830/threedollars/ui/category/TruckByMenuFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/category/TruckByMenuFragment.kt
@@ -122,16 +122,12 @@ class TruckByMenuFragment :
                 viewModel.requestStoreInfo(currentPosition)
             }
         }
+
+        val homeStoreEmptyResponseList = listOf(HomeStoreEmptyResponse(R.string.recruit_boss_title, R.string.recruit_boss_body))
+
         viewModel.storeByReview.observe(viewLifecycleOwner) {
             if (it.isNullOrEmpty()) {
-                truckStoreByReviewAdapters.submitEmptyList(
-                    listOf(
-                        HomeStoreEmptyResponse(
-                            emptyTitle = R.string.recruit_boss_title,
-                            emptyBody = R.string.recruit_boss_body
-                        )
-                    )
-                )
+                truckStoreByReviewAdapters.submitEmptyList(homeStoreEmptyResponseList)
             } else {
                 truckStoreByReviewAdapters.submitList(it)
             }
@@ -139,14 +135,7 @@ class TruckByMenuFragment :
         }
         viewModel.storeByDistance.observe(viewLifecycleOwner) {
             if (it.isNullOrEmpty()) {
-                truckStoreByDistanceAdapters.submitEmptyList(
-                    listOf(
-                        HomeStoreEmptyResponse(
-                            emptyTitle = R.string.recruit_boss_title,
-                            emptyBody = R.string.recruit_boss_body
-                        )
-                    )
-                )
+                truckStoreByDistanceAdapters.submitEmptyList(homeStoreEmptyResponseList)
             } else {
                 truckStoreByDistanceAdapters.submitList(it)
             }

--- a/app/src/main/java/com/zion830/threedollars/ui/category/TruckByMenuFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/category/TruckByMenuFragment.kt
@@ -123,38 +123,34 @@ class TruckByMenuFragment :
             }
         }
         viewModel.storeByReview.observe(viewLifecycleOwner) {
-            it?.let {
-                if (it.isEmpty()) {
-                    truckStoreByReviewAdapters.submitEmptyList(
-                        listOf(
-                            HomeStoreEmptyResponse(
-                                emptyTitle = R.string.recruit_boss_title,
-                                emptyBody = R.string.recruit_boss_body
-                            )
+            if (it.isNullOrEmpty()) {
+                truckStoreByReviewAdapters.submitEmptyList(
+                    listOf(
+                        HomeStoreEmptyResponse(
+                            emptyTitle = R.string.recruit_boss_title,
+                            emptyBody = R.string.recruit_boss_body
                         )
                     )
-                } else {
-                    truckStoreByReviewAdapters.submitList(it)
-                }
-                popupViewModel.getPopups("STORE_CATEGORY_LIST")
+                )
+            } else {
+                truckStoreByReviewAdapters.submitList(it)
             }
+            popupViewModel.getPopups("STORE_CATEGORY_LIST")
         }
         viewModel.storeByDistance.observe(viewLifecycleOwner) {
-            it?.let {
-                if (it.isEmpty()) {
-                    truckStoreByDistanceAdapters.submitEmptyList(
-                        listOf(
-                            HomeStoreEmptyResponse(
-                                emptyTitle = R.string.recruit_boss_title,
-                                emptyBody = R.string.recruit_boss_body
-                            )
+            if (it.isNullOrEmpty()) {
+                truckStoreByDistanceAdapters.submitEmptyList(
+                    listOf(
+                        HomeStoreEmptyResponse(
+                            emptyTitle = R.string.recruit_boss_title,
+                            emptyBody = R.string.recruit_boss_body
                         )
                     )
-                } else {
-                    truckStoreByDistanceAdapters.submitList(it)
-                }
-                popupViewModel.getPopups("STORE_CATEGORY_LIST")
+                )
+            } else {
+                truckStoreByDistanceAdapters.submitList(it)
             }
+            popupViewModel.getPopups("STORE_CATEGORY_LIST")
         }
     }
 

--- a/app/src/main/java/com/zion830/threedollars/ui/food_truck_store_detail/FoodTruckReviewActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/food_truck_store_detail/FoodTruckReviewActivity.kt
@@ -35,7 +35,7 @@ class FoodTruckReviewActivity :
         storeId = intent.getStringExtra(KEY_STORE_ID).toString()
 
         binding.btnBack.setOnClickListener {
-            val intent = FoodTruckStoreDetailActivity.getIntent(this,storeId)
+            val intent = FoodTruckStoreDetailActivity.getIntent(this, storeId)
             startActivity(intent)
             finish()
         }
@@ -73,7 +73,7 @@ class FoodTruckReviewActivity :
                     duration = Toast.LENGTH_LONG
                     view = binding.root
                 }.show()
-                val intent = FoodTruckStoreDetailActivity.getIntent(this,storeId)
+                val intent = FoodTruckStoreDetailActivity.getIntent(this, storeId)
                 startActivity(intent)
                 finish()
             } else {

--- a/app/src/main/java/com/zion830/threedollars/ui/home/SearchAddressFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/SearchAddressFragment.kt
@@ -33,10 +33,9 @@ class SearchAddressFragment : BaseFragment<FragmentSearchByAddressBinding, HomeV
         adapter = SearchAddressRecyclerAdapter(object : OnItemClickListener<Document> {
             override fun onClick(item: Document) {
                 val location = LatLng(item.y.toDouble(), item.x.toDouble())
-                if(arguments?.getBoolean(IS_ROAD_FOOD_MODE) == true){
+                if (arguments?.getBoolean(IS_ROAD_FOOD_MODE) == true) {
                     viewModel.requestHomeItem(location)
-                }
-                else{
+                } else {
                     viewModel.getBossNearStore(location)
                 }
                 searchViewModel.updateLatLng(location)
@@ -71,14 +70,15 @@ class SearchAddressFragment : BaseFragment<FragmentSearchByAddressBinding, HomeV
             false
         }
     }
+
     companion object {
 
         const val IS_ROAD_FOOD_MODE = "IS_ROAD_FOOD_MODE"
 
-        fun newInstance(isRoadFoodMode : Boolean) =
+        fun newInstance(isRoadFoodMode: Boolean) =
             SearchAddressFragment().apply {
                 arguments = Bundle().apply {
-                        putBoolean(IS_ROAD_FOOD_MODE, isRoadFoodMode)
+                    putBoolean(IS_ROAD_FOOD_MODE, isRoadFoodMode)
                 }
             }
     }

--- a/app/src/main/java/com/zion830/threedollars/ui/home/SearchAddressViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/SearchAddressViewModel.kt
@@ -14,7 +14,7 @@ import zion830.com.common.base.BaseViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class SearchAddressViewModel @Inject constructor(private val repository : MapDataSource) : BaseViewModel() {
+class SearchAddressViewModel @Inject constructor(private val repository: MapDataSource) : BaseViewModel() {
 
     private val _searchResult: MutableLiveData<SearchAddressResponse?> = MutableLiveData()
     val searchResult: LiveData<SearchAddressResponse?> = _searchResult

--- a/app/src/main/java/com/zion830/threedollars/ui/mypage/vm/FAQViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/mypage/vm/FAQViewModel.kt
@@ -16,7 +16,7 @@ import zion830.com.common.base.BaseViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class FAQViewModel @Inject constructor(private val userDataSource: UserDataSource): BaseViewModel() {
+class FAQViewModel @Inject constructor(private val userDataSource: UserDataSource) : BaseViewModel() {
 
     val faqTags: LiveData<List<FAQCategory>> = liveData(Dispatchers.IO + coroutineExceptionHandler) {
         val result = userDataSource.getFAQCategory()

--- a/app/src/main/java/com/zion830/threedollars/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/splash/SplashViewModel.kt
@@ -108,7 +108,7 @@ class SplashViewModel @Inject constructor(
         }
     }
 
-    fun putPushInformationToken(informationRequest: PushInformationTokenRequest){
+    fun putPushInformationToken(informationRequest: PushInformationTokenRequest) {
         viewModelScope.launch(coroutineExceptionHandler) {
             userDataSource.putPushInformationToken(informationRequest)
         }

--- a/app/src/main/java/com/zion830/threedollars/utils/StringUtils.kt
+++ b/app/src/main/java/com/zion830/threedollars/utils/StringUtils.kt
@@ -79,6 +79,7 @@ object StringUtils {
             ""
         }
     }
+
     fun TextView.textPartTypeface(changeText: String?, @StyleRes style: Int, isLast: Boolean = false) {
         if (changeText == null)
             return

--- a/app/src/main/java/com/zion830/threedollars/utils/SystemUtils.kt
+++ b/app/src/main/java/com/zion830/threedollars/utils/SystemUtils.kt
@@ -129,8 +129,8 @@ fun Context.shareWithKakao(
     title: String?,
     description: String?,
     imageUrl: String?,
-    storeId : String?,
-    type : String?
+    storeId: String?,
+    type: String?
 ) {
     if (LoginClient.instance.isKakaoTalkLoginAvailable(this)) {
         val feed = FeedTemplate(
@@ -146,8 +146,8 @@ fun Context.shareWithKakao(
                     link = Link(
                         webUrl = shareFormat.shareUrl,
                         mobileWebUrl = shareFormat.shareUrl,
-                        androidExecParams = mapOf("storeId" to storeId.toString(),"storeType" to type.toString()),
-                        iosExecParams = mapOf("storeId" to storeId.toString(),"storeType" to type.toString())
+                        androidExecParams = mapOf("storeId" to storeId.toString(), "storeType" to type.toString()),
+                        iosExecParams = mapOf("storeId" to storeId.toString(), "storeType" to type.toString())
                     )
                 )
             )


### PR DESCRIPTION
한식 카테고리 Id가 빌드 타입에 따라 달라서 호출이 안되던 문제 해결
푸드 트럭 탭 data를 엘비스 연산자로 처리하고 있어서 null일때 광고를 안나오는 문제를 해결 했습니다.
코드 스타일을 맞춤에 한번에 코드 정리를 진행하였습니다.

현재 간혈적으로
홈 화면 진입시 카드뷰 위치가 첫번째가 아닌 두번째로 먼저 이동되는 버그 (승호님 제보)
![image](https://user-images.githubusercontent.com/49590389/204170754-55655064-303e-4d6f-8aaa-3d59c655fff4.png)
주소를 못 불러와서 아무런 가게 데이터가 안 뜨는 이슈(현식님 승호님 제보)
https://3dollarsinhearts.slack.com/archives/C01EUAT55CJ/p1669294395924349
두 버그가 있는데 구현이 안돼서 수정을 못했습니다.
혹시 발견하게 되신다면 확인 부탁드리겠습니다.