### PR TITLE
TH-19 홈 리스트화면 광고 구좌 추가

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/ui/dialog/SelectCategoryDialogFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/dialog/SelectCategoryDialogFragment.kt
@@ -1,12 +1,12 @@
 package com.zion830.threedollars.ui.dialog
 
 import android.content.Intent
+import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.graphics.toColorInt
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -127,10 +127,12 @@ class SelectCategoryDialogFragment :
                             binding.tvAdBody.text = popup.subTitle.content
 
                             popup.title.fontColor.let {
-                                binding.tvAdTitle.setTextColor(it.toColorInt())
-                                binding.tvAdBody.setTextColor(it.toColorInt())
+                                if (it.isNotEmpty()) {
+                                    binding.tvAdTitle.setTextColor(Color.parseColor(it))
+                                    binding.tvAdBody.setTextColor(Color.parseColor(it))
+                                }
                             }
-                            popup.background.color.let { binding.cdAdCategory.setCardBackgroundColor(it.toColorInt()) }
+                            popup.background.color.let { if (it.isNotEmpty()) binding.cdAdCategory.setCardBackgroundColor(Color.parseColor(it)) }
 
                             binding.ivAdImage.loadUrlImg(popup.image.url)
 

--- a/app/src/main/java/com/zion830/threedollars/ui/home/adapter/AroundStoreListViewRecyclerAdapter.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/adapter/AroundStoreListViewRecyclerAdapter.kt
@@ -24,6 +24,7 @@ import zion830.com.common.base.BaseDiffUtilCallback
 
 class AroundStoreListViewRecyclerAdapter(
     private val clickListener: OnItemClickListener<ContentModel>,
+    private val clickAdListener:OnItemClickListener<AdvertisementModelV2>
 ) : ListAdapter<AdAndStoreItem, ViewHolder>(BaseDiffUtilCallback()) {
     private var emptyAd: AdvertisementModelV2? = null
     override fun getItemViewType(position: Int): Int = when (getItem(position)) {
@@ -49,11 +50,11 @@ class AroundStoreListViewRecyclerAdapter(
         }
 
         VIEW_TYPE_AD -> {
-            NearStoreAdListViewViewHolder(ItemListViewAdBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+            NearStoreAdListViewViewHolder(ItemListViewAdBinding.inflate(LayoutInflater.from(parent.context), parent, false),clickAdListener)
         }
 
         else -> {
-            NearStoreEmptyListViewViewHolder(ItemListViewEmptyBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+            NearStoreEmptyListViewViewHolder(ItemListViewEmptyBinding.inflate(LayoutInflater.from(parent.context), parent, false),clickAdListener)
         }
     }
 
@@ -84,10 +85,11 @@ class AroundStoreListViewRecyclerAdapter(
     }
 }
 
-class NearStoreEmptyListViewViewHolder(private val binding: ItemListViewEmptyBinding) : ViewHolder(binding.root) {
+class NearStoreEmptyListViewViewHolder(private val binding: ItemListViewEmptyBinding, private val clickAdListener: OnItemClickListener<AdvertisementModelV2>) : ViewHolder(binding.root) {
     fun bind(advertisementModelV2: AdvertisementModelV2?) {
         binding.itemListViewAd.root.isVisible = advertisementModelV2 == null
         advertisementModelV2?.let {
+            binding.root.setOnClickListener { clickAdListener.onClick(advertisementModelV2) }
             binding.itemListViewAd.imgAd.loadImage(it.image.url)
             binding.itemListViewAd.tvAdTitle.text = it.title.content
             binding.itemListViewAd.tvAdBody.text = it.subTitle.content
@@ -98,8 +100,9 @@ class NearStoreEmptyListViewViewHolder(private val binding: ItemListViewEmptyBin
     }
 }
 
-class NearStoreAdListViewViewHolder(private val binding: ItemListViewAdBinding) : ViewHolder(binding.root) {
+class NearStoreAdListViewViewHolder(private val binding: ItemListViewAdBinding, private val clickAdListener: OnItemClickListener<AdvertisementModelV2>) : ViewHolder(binding.root) {
     fun bind(advertisementModelV2: AdvertisementModelV2) {
+        binding.root.setOnClickListener { clickAdListener.onClick(advertisementModelV2) }
         binding.imgAd.loadImage(advertisementModelV2.image.url)
         binding.tvAdTitle.text = advertisementModelV2.title.content
         binding.tvAdBody.text = advertisementModelV2.subTitle.content

--- a/app/src/main/java/com/zion830/threedollars/ui/home/adapter/AroundStoreListViewRecyclerAdapter.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/adapter/AroundStoreListViewRecyclerAdapter.kt
@@ -1,11 +1,13 @@
 package com.zion830.threedollars.ui.home.adapter
 
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.home.domain.data.advertisement.AdvertisementModelV2
 import com.home.domain.data.store.ContentModel
 import com.threedollar.common.data.AdAndStoreItem
 import com.threedollar.common.ext.loadImage
@@ -13,6 +15,7 @@ import com.threedollar.common.listener.OnItemClickListener
 import com.threedollar.common.utils.Constants.USER_STORE
 import com.zion830.threedollars.GlobalApplication
 import com.zion830.threedollars.R
+import com.zion830.threedollars.databinding.ItemListViewAdBinding
 import com.zion830.threedollars.databinding.ItemListViewBinding
 import com.zion830.threedollars.databinding.ItemListViewEmptyBinding
 import com.zion830.threedollars.utils.StringUtils
@@ -22,10 +25,14 @@ import zion830.com.common.base.BaseDiffUtilCallback
 class AroundStoreListViewRecyclerAdapter(
     private val clickListener: OnItemClickListener<ContentModel>,
 ) : ListAdapter<AdAndStoreItem, ViewHolder>(BaseDiffUtilCallback()) {
-
+    private var emptyAd: AdvertisementModelV2? = null
     override fun getItemViewType(position: Int): Int = when (getItem(position)) {
         is ContentModel -> {
             VIEW_TYPE_STORE
+        }
+
+        is AdvertisementModelV2 -> {
+            VIEW_TYPE_AD
         }
 
         else -> {
@@ -41,6 +48,10 @@ class AroundStoreListViewRecyclerAdapter(
             )
         }
 
+        VIEW_TYPE_AD -> {
+            NearStoreAdListViewViewHolder(ItemListViewAdBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+        }
+
         else -> {
             NearStoreEmptyListViewViewHolder(ItemListViewEmptyBinding.inflate(LayoutInflater.from(parent.context), parent, false))
         }
@@ -52,17 +63,51 @@ class AroundStoreListViewRecyclerAdapter(
                 holder.bind(getItem(position) as ContentModel)
             }
 
-            is NearStoreEmptyListViewViewHolder -> {}
+            is NearStoreAdListViewViewHolder -> {
+                holder.bind(getItem(position) as AdvertisementModelV2)
+            }
+
+            is NearStoreEmptyListViewViewHolder -> {
+                holder.bind(emptyAd)
+            }
         }
+    }
+
+    fun setAd(advertisementModelV2: AdvertisementModelV2?) {
+        emptyAd = advertisementModelV2
     }
 
     companion object {
         private const val VIEW_TYPE_EMPTY = 0
         private const val VIEW_TYPE_STORE = 1
+        private const val VIEW_TYPE_AD = 2
     }
 }
 
-class NearStoreEmptyListViewViewHolder(binding: ItemListViewEmptyBinding) : ViewHolder(binding.root)
+class NearStoreEmptyListViewViewHolder(private val binding: ItemListViewEmptyBinding) : ViewHolder(binding.root) {
+    fun bind(advertisementModelV2: AdvertisementModelV2?) {
+        binding.itemListViewAd.root.isVisible = advertisementModelV2 == null
+        advertisementModelV2?.let {
+            binding.itemListViewAd.imgAd.loadImage(it.image.url)
+            binding.itemListViewAd.tvAdTitle.text = it.title.content
+            binding.itemListViewAd.tvAdBody.text = it.subTitle.content
+            it.title.fontColor.let { if(it.isNotEmpty()) binding.itemListViewAd.tvAdBody.setTextColor(Color.parseColor(it)) }
+            it.subTitle.fontColor.let { if(it.isNotEmpty()) binding.itemListViewAd.tvAdBody.setTextColor(Color.parseColor(it)) }
+            it.background.color.let { if(it.isNotEmpty()) binding.itemListViewAd.constraintAd.setBackgroundColor(Color.parseColor(it)) }
+        }
+    }
+}
+
+class NearStoreAdListViewViewHolder(private val binding: ItemListViewAdBinding) : ViewHolder(binding.root) {
+    fun bind(advertisementModelV2: AdvertisementModelV2) {
+        binding.imgAd.loadImage(advertisementModelV2.image.url)
+        binding.tvAdTitle.text = advertisementModelV2.title.content
+        binding.tvAdBody.text = advertisementModelV2.subTitle.content
+        advertisementModelV2.title.fontColor.let { if(it.isNotEmpty()) binding.tvAdBody.setTextColor(Color.parseColor(it)) }
+        advertisementModelV2.subTitle.fontColor.let { if(it.isNotEmpty()) binding.tvAdBody.setTextColor(Color.parseColor(it)) }
+        advertisementModelV2.background.color.let { if(it.isNotEmpty()) binding.constraintAd.setBackgroundColor(Color.parseColor(it)) }
+    }
+}
 
 class NearStoreListViewViewHolder(
     private val binding: ItemListViewBinding,

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -263,7 +263,12 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
 
                 launch {
                     viewModel.aroundStoreModels.collect { adAndStoreItems ->
-                        adapter.submitList(adAndStoreItems)
+                        val resultList = mutableListOf<AdAndStoreItem>()
+                        resultList.addAll(adAndStoreItems)
+                        viewModel.advertisementModel.value?.let { advertisementModel ->
+                            resultList.add(1, advertisementModel)
+                        }
+                        adapter.submitList(resultList)
                         val list = adAndStoreItems.filterIsInstance<ContentModel>()
                         naverMapFragment.addStoreMarkers(R.drawable.ic_store_off, list) {
                             onStoreClicked(it)

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeListViewFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeListViewFragment.kt
@@ -17,10 +17,12 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import com.google.android.gms.ads.AdRequest
+import com.home.domain.data.advertisement.AdvertisementModelV2
 import com.home.domain.data.store.ContentModel
 import com.home.presentation.data.HomeSortType
 import com.home.presentation.data.HomeStoreType
 import com.threedollar.common.base.BaseFragment
+import com.threedollar.common.data.AdAndStoreItem
 import com.threedollar.common.listener.OnItemClickListener
 import com.threedollar.common.utils.Constants
 import com.threedollar.common.utils.Constants.CLICK_STORE
@@ -28,8 +30,8 @@ import com.zion830.threedollars.EventTracker
 import com.zion830.threedollars.R
 import com.zion830.threedollars.databinding.FragmentHomeListViewBinding
 import com.zion830.threedollars.ui.dialog.SelectCategoryDialogFragment
-import com.zion830.threedollars.ui.home.viewModel.HomeViewModel
 import com.zion830.threedollars.ui.home.adapter.AroundStoreListViewRecyclerAdapter
+import com.zion830.threedollars.ui.home.viewModel.HomeViewModel
 import com.zion830.threedollars.ui.storeDetail.boss.ui.BossStoreDetailActivity
 import com.zion830.threedollars.ui.storeDetail.user.ui.StoreDetailActivity
 import com.zion830.threedollars.utils.showToast
@@ -136,7 +138,6 @@ class HomeListViewFragment : BaseFragment<FragmentHomeListViewBinding, HomeViewM
                 if (isFilterCertifiedStores) R.drawable.ic_certification_check_on else R.drawable.ic_certification_check_off
             )
             binding.certifiedStoreTextView.setCompoundDrawablesWithIntrinsicBounds(drawableStart, null, null, null)
-            getNearStore()
         }
     }
 
@@ -173,8 +174,12 @@ class HomeListViewFragment : BaseFragment<FragmentHomeListViewBinding, HomeViewM
                         binding.listTitleTextView.text = viewModel.selectCategory.value.description.ifEmpty {
                             getString(R.string.fragment_home_all_menu)
                         }
-
-                        adapter.submitList(adAndStoreItems.filterIsInstance<ContentModel>())
+                        val resultList = mutableListOf<AdAndStoreItem>()
+                        resultList.addAll(adAndStoreItems)
+                        viewModel.advertisementListModel.value?.let { advertisementModel ->
+                            resultList.add(1, advertisementModel)
+                        }
+                        adapter.submitList(resultList)
                         delay(200L)
                         binding.listRecyclerView.scrollToPosition(0)
                     }
@@ -198,6 +203,11 @@ class HomeListViewFragment : BaseFragment<FragmentHomeListViewBinding, HomeViewM
                                 getString(R.string.fragment_home_filter_latest)
                             }
                         }
+                    }
+                }
+                launch {
+                    viewModel.advertisementListModel.collect {
+                        adapter.setAd(advertisementModelV2 = it)
                     }
                 }
                 launch {

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeListViewFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeListViewFragment.kt
@@ -1,5 +1,6 @@
 package com.zion830.threedollars.ui.home.ui
 
+import android.content.Intent
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
@@ -65,6 +66,15 @@ class HomeListViewFragment : BaseFragment<FragmentHomeListViewBinding, HomeViewM
                         StoreDetailActivity.getIntent(requireContext(), item.storeModel.storeId.toInt(), false)
                     startActivityForResult(intent, Constants.SHOW_STORE_BY_CATEGORY)
                 }
+            }
+        }, object : OnItemClickListener<AdvertisementModelV2> {
+            override fun onClick(item: AdvertisementModelV2) {
+                val bundle = Bundle().apply {
+                    putString("screen", "home_list")
+                    putString("advertisement_id", item.advertisementId.toString())
+                }
+                EventTracker.logEvent(Constants.CLICK_AD_BANNER, bundle)
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(item.link.url)))
             }
         })
     }

--- a/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
@@ -43,11 +43,15 @@ class HomeViewModel @Inject constructor(private val homeRepository: HomeReposito
     private val _advertisementModel: MutableStateFlow<AdvertisementModelV2?> = MutableStateFlow(null)
     val advertisementModel: StateFlow<AdvertisementModelV2?> get() = _advertisementModel
 
+    private val _advertisementListModel: MutableStateFlow<AdvertisementModelV2?> = MutableStateFlow(null)
+    val advertisementListModel: StateFlow<AdvertisementModelV2?> get() = _advertisementListModel
+
     private val _homeFilterEvent: MutableStateFlow<HomeFilterEvent> = MutableStateFlow(HomeFilterEvent())
     val homeFilterEvent: StateFlow<HomeFilterEvent> get() = _homeFilterEvent
 
     init {
         getAdvertisement()
+        getAdvertisementList()
     }
 
     fun getUserInfo() {
@@ -99,9 +103,6 @@ class HomeViewModel @Inject constructor(private val homeRepository: HomeReposito
                         resultList.add(StoreEmptyResponse())
                     } else {
                         it.data?.let { it1 -> resultList.addAll(it1.contentModels) }
-                        advertisementModel.value?.let { advertisementModel ->
-                            resultList.add(1, advertisementModel)
-                        }
                     }
                     _aroundStoreModels.value = resultList
                 } else {
@@ -156,6 +157,18 @@ class HomeViewModel @Inject constructor(private val homeRepository: HomeReposito
             homeRepository.getAdvertisements(AdvertisementsPosition.MAIN_PAGE_CARD).collect {
                 if (it.ok) {
                     _advertisementModel.value = it.data?.firstOrNull()
+                } else {
+                    _serverError.emit(it.message)
+                }
+            }
+        }
+    }
+
+    private fun getAdvertisementList() {
+        viewModelScope.launch(coroutineExceptionHandler) {
+            homeRepository.getAdvertisements(AdvertisementsPosition.STORE_LIST).collect {
+                if (it.ok) {
+                    _advertisementListModel.value = it.data?.firstOrNull()
                 } else {
                     _serverError.emit(it.message)
                 }

--- a/app/src/main/res/layout/item_list_view_ad.xml
+++ b/app/src/main/res/layout/item_list_view_ad.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:foreground="?attr/selectableItemBackgroundBorderless"
+    app:cardCornerRadius="20dp"
+    app:cardUseCompatPadding="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/white"
+        android:id="@+id/constraintAd"
+        android:focusable="true"
+        tools:ignore="UnusedAttribute">
+
+        <ImageView
+            android:id="@+id/imgAd"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tvAd"
+            android:layout_width="32dp"
+            android:layout_height="18dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/rect_radius_40_pink_100"
+            android:gravity="center"
+            android:text="@string/ad"
+            android:textColor="@color/pink"
+            android:textSize="10dp"
+            app:layout_constraintStart_toEndOf="@id/imgAd"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tvAdTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="4dp"
+            android:textColor="@color/color_black"
+            android:textSize="16dp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/imgAd"
+            app:layout_constraintTop_toBottomOf="@id/tvAd" />
+
+        <TextView
+            android:id="@+id/tvAdBody"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="2dp"
+            android:layout_marginBottom="12dp"
+            android:textColor="@color/gray50"
+            android:textSize="12dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/imgAd"
+            app:layout_constraintTop_toBottomOf="@id/tvAdTitle"
+            app:layout_constraintVertical_bias="0" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_list_view_empty.xml
+++ b/app/src/main/res/layout/item_list_view_empty.xml
@@ -26,7 +26,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
+        android:layout_marginBottom="30dp"
         android:text="@string/empty_store_msg"
         android:textColor="@color/gray70" />
+
+    <include
+        android:id="@+id/itemListViewAd"
+        layout="@layout/item_list_view_ad" />
 
 </LinearLayout>


### PR DESCRIPTION
### 작업내용
- 리스트 광고 추가
- 컬러 파싱 조건 추가

### 참고
현재 리스트와 지도화면이 activityViewModel로 공유되고 있어서 매번 호출하는데 activityViewModel을 사용한 이상 공유하는게 어떨까 싶어서 구조변경이 좀 필요 할 것 같습니다 