### PR TITLE
[Feat] - 동네 인기 가게 조회시 파라미터 누락 수정 / 사진 제보 타임 아웃 처리

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/ui/storeDetail/user/viewModel/StoreDetailViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/storeDetail/user/viewModel/StoreDetailViewModel.kt
@@ -151,7 +151,7 @@ class StoreDetailViewModel @Inject constructor(private val homeRepository: HomeR
                 storeId = storeId
             )
             if (result == null) {
-                _serverError.emit("사진 용량이 너무 커요ㅠㅠ")
+                _serverError.emit("인터넷이 불안정해요.")
             } else {
                 getImage(storeId)
             }

--- a/app/src/main/java/com/zion830/threedollars/ui/storeDetail/user/viewModel/StoreDetailViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/storeDetail/user/viewModel/StoreDetailViewModel.kt
@@ -67,7 +67,7 @@ class StoreDetailViewModel @Inject constructor(private val homeRepository: HomeR
     val reportReasons: StateFlow<List<ReasonModel>?> get() = _reportReasons
 
     private val _reviewSuccessEvent = MutableSharedFlow<Boolean>()
-    val reviewSuccessEvent : SharedFlow<Boolean> get() = _reviewSuccessEvent
+    val reviewSuccessEvent: SharedFlow<Boolean> get() = _reviewSuccessEvent
 
     init {
         getReportReasons()
@@ -146,10 +146,16 @@ class StoreDetailViewModel @Inject constructor(private val homeRepository: HomeR
 
         viewModelScope.launch(coroutineExceptionHandler) {
             _uploadImageStatus.emit(true)
-            homeRepository.saveImages(images, storeId).collect {
+            val result = homeRepository.saveImages(
+                images = images,
+                storeId = storeId
+            )
+            if (result == null) {
+                _serverError.emit("사진 용량이 너무 커요ㅠㅠ")
+            } else {
                 getImage(storeId)
-                _uploadImageStatus.emit(false)
             }
+            _uploadImageStatus.emit(false)
         }
     }
 
@@ -209,8 +215,7 @@ class StoreDetailViewModel @Inject constructor(private val homeRepository: HomeR
                 homeRepository.postStoreReview(contents = content, rating = rating, storeId = storeId).collect {
                     if (it.ok) {
                         _reviewSuccessEvent.emit(true)
-                    }
-                    else{
+                    } else {
                         _serverError.emit(it.message)
                     }
                 }

--- a/community/presentation/src/main/java/com/threedollar/presentation/CommunityViewModel.kt
+++ b/community/presentation/src/main/java/com/threedollar/presentation/CommunityViewModel.kt
@@ -1,6 +1,5 @@
 package com.threedollar.presentation
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import com.threedollar.common.base.BaseViewModel
@@ -93,7 +92,11 @@ class CommunityViewModel @Inject constructor(private val communityRepository: Co
     fun getPopularStores(criteria: String, district: String) {
 
         viewModelScope.launch(coroutineExceptionHandler) {
-            communityRepository.getPopularStores(criteria, district, "").collect {
+            communityRepository.getPopularStores(
+                criteria = criteria,
+                district = district.ifBlank { "SEOUL_ALL" },
+                cursor = ""
+            ).collect {
                 if (it.ok) {
                     val list = it.data?.content.orEmpty()
                     if (list.isEmpty()) {

--- a/core/network/src/main/java/com/threedollar/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/threedollar/network/di/NetworkModule.kt
@@ -31,7 +31,7 @@ object NetworkModule {
     private const val KAKAO_SEARCH_URL = "https://dapi.kakao.com/"
     private const val KAKAO_LOGIN_URL = "https://kauth.kakao.com/"
     private const val BASE_URL: String = BuildConfig.BASE_URL
-    private const val TIME_OUT_SEC = 15L
+    private const val TIME_OUT_SEC = 5L
 
     @Qualifier
     @Retention(AnnotationRetention.BINARY)

--- a/core/network/src/main/java/com/threedollar/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/threedollar/network/di/NetworkModule.kt
@@ -31,7 +31,7 @@ object NetworkModule {
     private const val KAKAO_SEARCH_URL = "https://dapi.kakao.com/"
     private const val KAKAO_LOGIN_URL = "https://kauth.kakao.com/"
     private const val BASE_URL: String = BuildConfig.BASE_URL
-    private const val TIME_OUT_SEC = 5L
+    private const val TIME_OUT_SEC = 15L
 
     @Qualifier
     @Retention(AnnotationRetention.BINARY)

--- a/home/data/src/main/java/com/home/data/datasource/HomeRemoteDataSource.kt
+++ b/home/data/src/main/java/com/home/data/datasource/HomeRemoteDataSource.kt
@@ -32,7 +32,7 @@ import okhttp3.MultipartBody
 interface HomeRemoteDataSource {
 
     fun getAroundStores(
-        distanceM:Double,
+        distanceM: Double,
         categoryIds: Array<String>?,
         targetStores: Array<String>?,
         sortType: String,
@@ -89,7 +89,7 @@ interface HomeRemoteDataSource {
 
     fun deleteImage(imageId: Int): Flow<BaseResponse<String>>
 
-    fun saveImages(images: List<MultipartBody.Part>, storeId: Int): Flow<BaseResponse<List<SaveImagesResponse>>>
+    suspend fun saveImages(images: List<MultipartBody.Part>, storeId: Int): BaseResponse<List<SaveImagesResponse>>
 
     fun postStoreReview(storeReviewRequest: StoreReviewRequest): Flow<BaseResponse<ReviewContent>>
 

--- a/home/data/src/main/java/com/home/data/datasource/HomeRemoteDataSourceImpl.kt
+++ b/home/data/src/main/java/com/home/data/datasource/HomeRemoteDataSourceImpl.kt
@@ -157,9 +157,7 @@ class HomeRemoteDataSourceImpl @Inject constructor(private val serverApi: Server
         emit(apiResult(serverApi.deleteImage(imageId)))
     }
 
-    override fun saveImages(images: List<MultipartBody.Part>, storeId: Int): Flow<BaseResponse<List<SaveImagesResponse>>> = flow {
-        emit(apiResult(serverApi.saveImages(images, storeId)))
-    }
+    override suspend fun saveImages(images: List<MultipartBody.Part>, storeId: Int): BaseResponse<List<SaveImagesResponse>> = apiResult(serverApi.saveImages(images, storeId))
 
     override fun postStoreReview(storeReviewRequest: StoreReviewRequest): Flow<BaseResponse<ReviewContent>> = flow {
         emit(apiResult(serverApi.postStoreReview(storeReviewRequest)))

--- a/home/data/src/main/java/com/home/data/repository/HomeRepositoryImpl.kt
+++ b/home/data/src/main/java/com/home/data/repository/HomeRepositoryImpl.kt
@@ -56,7 +56,7 @@ class HomeRepositoryImpl @Inject constructor(
 ) :
     HomeRepository {
     override fun getAroundStores(
-        distanceM:Double,
+        distanceM: Double,
         categoryIds: Array<String>?,
         targetStores: Array<String>?,
         sortType: String,
@@ -201,8 +201,10 @@ class HomeRepositoryImpl @Inject constructor(
 
     override fun deleteImage(imageId: Int): Flow<BaseResponse<String>> = homeRemoteDataSource.deleteImage(imageId)
 
-    override fun saveImages(images: List<MultipartBody.Part>, storeId: Int): Flow<BaseResponse<List<SaveImagesModel>>> =
-        homeRemoteDataSource.saveImages(images, storeId).map {
+    override suspend fun saveImages(images: List<MultipartBody.Part>, storeId: Int): BaseResponse<List<SaveImagesModel>>? = runCatching {
+        homeRemoteDataSource.saveImages(images, storeId)
+    }.fold(
+        onSuccess = {
             BaseResponse(
                 ok = it.ok,
                 data = it.data?.map { response -> response.asModel() },
@@ -210,7 +212,12 @@ class HomeRepositoryImpl @Inject constructor(
                 resultCode = it.resultCode,
                 error = it.error,
             )
+        },
+        onFailure = {
+            null
         }
+    )
+
 
     override fun getStoreImages(storeId: Int): Flow<PagingData<ImageContentModel>> = Pager(PagingConfig(20)) {
         ImagePagingDataSource(storeId, serverApi)

--- a/home/domain/src/main/java/com/home/domain/repository/HomeRepository.kt
+++ b/home/domain/src/main/java/com/home/domain/repository/HomeRepository.kt
@@ -80,7 +80,7 @@ interface HomeRepository {
 
     fun deleteImage(imageId: Int): Flow<BaseResponse<String>>
 
-    fun saveImages(images: List<MultipartBody.Part>, storeId: Int): Flow<BaseResponse<List<SaveImagesModel>>>
+    suspend fun saveImages(images: List<MultipartBody.Part>, storeId: Int): BaseResponse<List<SaveImagesModel>>?
 
     fun getStoreImages(storeId: Int): Flow<PagingData<ImageContentModel>>
 


### PR DESCRIPTION
- 간헐적으로 `district`가 비어있을 때 `SEOUL_ALL`을 기본값으로 설정 했습니다.
- 서버 타임 아웃을 15초로 늘리고 사진 제보시 타임 아웃이 발생하면 로딩 바를 해제하고 사진 용량이 크다는 토스트 메시지를 띄울 수 있게 수정 했습니다.