### PR TITLE
TH-1025 : 설정화면 로딩 가운데로 이동

### DIFF
--- a/app/src/main/res/layout/fragment_mypage_setting.xml
+++ b/app/src/main/res/layout/fragment_mypage_setting.xml
@@ -431,10 +431,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_gravity="center"
+        tools:visibility="visible"/>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/setting_container"


### PR DESCRIPTION
- 부모가 FrameLayout이기 때문에 constraint가 적용되지 않아 좌측상단에 로딩이 표시되고 있었습니다.