### PR TITLE
TH-1039 : 서버 기반 동적 카테고리 적용

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/datasource/model/v2/response/store/CategoriesResponse.kt
+++ b/app/src/main/java/com/zion830/threedollars/datasource/model/v2/response/store/CategoriesResponse.kt
@@ -38,4 +38,6 @@ data class Classification(
     val type: String = "",
     @SerializedName("description")
     val description: String = "",
+    @SerializedName("priority")
+    val priority: Int = Int.MAX_VALUE,
 )

--- a/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryDialogFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryDialogFragment.kt
@@ -54,7 +54,6 @@ class SelectCategoryDialogFragment :
     override fun initView() {
         initCategoryList()
         initAd()
-//        initAdapter()
         initFlow()
     }
 

--- a/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryDialogFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryDialogFragment.kt
@@ -65,10 +65,10 @@ class SelectCategoryDialogFragment :
                     position = AdvertisementsPosition.MENU_CATEGORY_BANNER,
                     latLng = latLng
                 )
-                popupViewModel.getPopups(
-                    position = AdvertisementsPosition.MENU_CATEGORY_ICON,
-                    latLng = latLng
-                )
+//                popupViewModel.getPopups(
+//                    position = AdvertisementsPosition.MENU_CATEGORY_ICON,
+//                    latLng = latLng
+//                )
             }
         }
     }

--- a/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryEffect.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryEffect.kt
@@ -1,0 +1,5 @@
+package com.zion830.threedollars.ui.dialog.category
+
+sealed interface SelectCategoryEffect {
+    data object OnInitError : SelectCategoryEffect
+}

--- a/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryIntent.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryIntent.kt
@@ -1,0 +1,5 @@
+package com.zion830.threedollars.ui.dialog.category
+
+sealed interface SelectCategoryIntent {
+    data object OnInit : SelectCategoryIntent
+}

--- a/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryState.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryState.kt
@@ -1,0 +1,11 @@
+package com.zion830.threedollars.ui.dialog.category
+
+import kotlinx.collections.immutable.ImmutableList
+
+sealed interface SelectCategoryState {
+    data object Idle : SelectCategoryState
+
+    data class Success(
+        val categories: ImmutableList<StoreCategory>
+    ) : SelectCategoryState
+}

--- a/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/dialog/category/SelectCategoryViewModel.kt
@@ -1,0 +1,95 @@
+package com.zion830.threedollars.ui.dialog.category
+
+import androidx.lifecycle.viewModelScope
+import com.threedollar.common.base.UdfViewModel
+import com.zion830.threedollars.datasource.StoreDataSource
+import com.zion830.threedollars.datasource.model.v2.response.store.CategoriesResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class SelectCategoryViewModel @Inject constructor(
+    private val storeDataSource: StoreDataSource
+) : UdfViewModel<SelectCategoryIntent, SelectCategoryState, SelectCategoryEffect>() {
+
+    private val categories = MutableStateFlow<ImmutableList<StoreCategory>>(persistentListOf())
+
+    override val state: StateFlow<SelectCategoryState> = categories.mapLatest {
+        SelectCategoryState.Success(it)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000L),
+        initialValue = SelectCategoryState.Idle
+    )
+
+    private val _effect = Channel<SelectCategoryEffect>(
+        capacity = 64,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    override val effect: Flow<SelectCategoryEffect> = _effect.receiveAsFlow()
+
+    override fun dispatch(intent: SelectCategoryIntent) {
+        when (intent) {
+            is SelectCategoryIntent.OnInit -> {
+                onInit()
+            }
+        }
+    }
+
+    private fun onInit() {
+        if (state.value !is SelectCategoryState.Idle) {
+            return
+        }
+
+        launchIfIdle(
+            tag = "onInit"
+        ) {
+            storeDataSource.getCategories().collect {
+                val ret = it.body()
+                if (ret != null) {
+                    categories.value = ret.toStoreCategories()
+                } else {
+                    _effect.send(SelectCategoryEffect.OnInitError)
+                }
+            }
+        }
+    }
+
+    private fun CategoriesResponse.toStoreCategories(): ImmutableList<StoreCategory> = data.groupBy {
+        it.classification
+    }.mapValues { entry ->
+        StoreCategory(
+            classification = StoreCategoryClassification(
+                type = entry.key.type,
+                name = entry.key.description,
+                priority = entry.key.priority
+            ),
+            items = entry.value.map { value ->
+                StoreCategoryItem(
+                    id = value.categoryId,
+                    name = value.name,
+                    description = value.description,
+                    imageUrl = value.imageUrl,
+                    disableImageUrl = value.disableImageUrl,
+                    isNew = value.isNew
+                )
+            }
+        )
+    }.values.sortedBy {
+        it.classification.priority
+    }.toImmutableList()
+}

--- a/app/src/main/java/com/zion830/threedollars/ui/dialog/category/StoreCategory.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/dialog/category/StoreCategory.kt
@@ -1,0 +1,21 @@
+package com.zion830.threedollars.ui.dialog.category
+
+data class StoreCategory(
+    val classification: StoreCategoryClassification,
+    val items: List<StoreCategoryItem>,
+)
+
+data class StoreCategoryClassification(
+    val type: String,
+    val name: String,
+    val priority: Int
+)
+
+data class StoreCategoryItem(
+    val id: String,
+    val name: String,
+    val description: String,
+    val imageUrl: String,
+    val disableImageUrl: String,
+    val isNew: Boolean
+)

--- a/app/src/main/java/com/zion830/threedollars/ui/dialog/category/composable/CategoryListScreen.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/dialog/category/composable/CategoryListScreen.kt
@@ -1,0 +1,379 @@
+package com.zion830.threedollars.ui.dialog.category.composable
+
+import androidx.annotation.IntRange
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineBreak
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import base.compose.ColorBlack
+import base.compose.ColorWhite
+import base.compose.Gray70
+import base.compose.Gray90
+import base.compose.Pink
+import base.compose.Pink100
+import base.compose.dpToSp
+import coil3.compose.AsyncImage
+import com.zion830.threedollars.core.ui.component.compose.components.FlowWithLifecycleEffect
+import com.zion830.threedollars.core.ui.component.compose.components.VerticalSpacer
+import com.zion830.threedollars.ui.dialog.category.SelectCategoryEffect
+import com.zion830.threedollars.ui.dialog.category.SelectCategoryIntent
+import com.zion830.threedollars.ui.dialog.category.SelectCategoryState
+import com.zion830.threedollars.ui.dialog.category.SelectCategoryViewModel
+import com.zion830.threedollars.ui.dialog.category.StoreCategory
+import com.zion830.threedollars.ui.dialog.category.StoreCategoryItem
+import com.zion830.threedollars.ui.home.viewModel.HomeViewModel
+import kotlinx.collections.immutable.ImmutableList
+import com.threedollar.common.R as CommonR
+import com.zion830.threedollars.core.designsystem.R as DesignSystemR
+
+private const val CATEGORY_GRID_SIZE = 4
+
+@Composable
+fun CategoryListScreen(
+    viewModel: SelectCategoryViewModel,
+    homeViewModel: HomeViewModel,
+    onSelected: (StoreCategoryItem?) -> Unit
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val homeUiState by homeViewModel.uiState.collectAsStateWithLifecycle()
+
+    var showError by remember {
+        mutableStateOf(false)
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.dispatch(SelectCategoryIntent.OnInit)
+    }
+
+    FlowWithLifecycleEffect(viewModel.effect) {
+        when (it) {
+            is SelectCategoryEffect.OnInitError -> {
+                showError = true
+            }
+        }
+    }
+
+    when (val state = state) {
+        is SelectCategoryState.Success -> {
+            CategoryList(
+                categories = state.categories,
+                selected = homeUiState.selectedCategory,
+                onSelected = { selected ->
+                    onSelected.invoke(
+                        selected.takeIf { homeUiState.selectedCategory != it }
+                    )
+                }
+            )
+        }
+
+        is SelectCategoryState.Idle -> {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp)
+            )
+        }
+    }
+
+    if (showError) {
+        AlertDialog(
+            onDismissRequest = {
+                showError = false
+            },
+            title = {
+                Text(
+                    text = stringResource(CommonR.string.error_unknown_title),
+                    color = Gray90,
+                    fontSize = 16.sp
+                )
+
+            },
+            text = {
+                Text(
+                    text = stringResource(CommonR.string.error_unknown_message),
+                    color = Gray90,
+                    fontSize = 16.sp
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    colors = ButtonDefaults.textButtonColors(
+                        backgroundColor = ColorWhite
+                    ),
+                    onClick = {
+                        viewModel.dispatch(SelectCategoryIntent.OnInit)
+                        showError = false
+                    }
+                ) {
+                    Text(
+                        text = stringResource(CommonR.string.retry),
+                        color = Gray90,
+                        fontSize = 16.sp
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    colors = ButtonDefaults.textButtonColors(
+                        backgroundColor = ColorWhite
+                    ),
+                    onClick = {
+                        showError = false
+                    }
+                ) {
+                    Text(
+                        text = stringResource(CommonR.string.cancel),
+                        color = Gray90,
+                        fontSize = 16.sp
+                    )
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun CategoryList(
+    categories: ImmutableList<StoreCategory>,
+    selected: StoreCategoryItem?,
+    onSelected: (StoreCategoryItem) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        horizontalAlignment = Alignment.Start
+    ) {
+        categories.forEach {
+            CategoryListItem(it, selected, onSelected)
+        }
+    }
+}
+
+@Composable
+private fun CategoryListItem(
+    item: StoreCategory,
+    selected: StoreCategoryItem?,
+    onSelected: (StoreCategoryItem) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        horizontalAlignment = Alignment.Start
+    ) {
+        Text(
+            text = item.classification.name,
+            fontSize = dpToSp(16),
+            color = ColorBlack,
+            fontWeight = FontWeight.W700,
+            lineHeight = dpToSp(24),
+            letterSpacing = 0.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        VerticalSpacer(12)
+
+        CategoryGridLayout(
+            size = CATEGORY_GRID_SIZE,
+            horizontalSpacing = 12.dp,
+            verticalSpacing = 12.dp
+        ) {
+            item.items.forEach {
+                CategoryGridItem(
+                    item = it,
+                    selected = it == selected,
+                    onSelected = onSelected
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryGridItem(
+    item: StoreCategoryItem,
+    selected: Boolean,
+    onSelected: (StoreCategoryItem) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .clickable { onSelected.invoke(item) },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight(),
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            AsyncImage(
+                model = item.imageUrl,
+                contentDescription = item.name,
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .then(
+                        other = if (selected) {
+                            Modifier
+                                .border(
+                                    width = 1.dp,
+                                    color = Pink,
+                                    shape = CircleShape
+                                )
+                                .background(
+                                    color = Pink100,
+                                    shape = CircleShape
+                                )
+                        } else {
+                            Modifier
+                        }
+                    )
+                    .fillMaxWidth()
+                    .aspectRatio(1f),
+                contentScale = ContentScale.Fit
+            )
+
+            Text(
+                text = item.name,
+                fontSize = dpToSp(12),
+                color = if (selected) {
+                    Pink
+                } else {
+                    Gray70
+                },
+                fontWeight = if (selected) {
+                    FontWeight.W700
+                } else {
+                    FontWeight.W500
+                },
+                lineHeight = dpToSp(18),
+                letterSpacing = 0.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                style = LocalTextStyle.current.copy(
+                    lineBreak = LineBreak.Heading
+                )
+            )
+        }
+        if (item.isNew) {
+            Image(
+                painter = painterResource(DesignSystemR.drawable.ic_new_badge),
+                contentDescription = item.name,
+                modifier = Modifier
+                    .width(32.dp)
+                    .height(14.dp)
+                    .align(Alignment.TopStart)
+            )
+        }
+    }
+}
+
+/**
+ * LazyGrid는 wrap_contnet를 미지원 하므로 커스텀 레이아웃 필요함
+ */
+@Composable
+private fun CategoryGridLayout(
+    @IntRange(from = 1) size: Int,
+    horizontalSpacing: Dp = 0.dp,
+    verticalSpacing: Dp = 0.dp,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Layout(
+        modifier = modifier,
+        content = content
+    ) { measurables, constraints ->
+
+        val totalItems = measurables.size
+        val rowCount = (totalItems + size - 1) / size
+
+        val hSpacingPx = horizontalSpacing.roundToPx()
+        val vSpacingPx = verticalSpacing.roundToPx()
+
+        // Horizontal spacing affects width!
+        val totalHorizontalSpacing = hSpacingPx * (size - 1)
+        val itemWidth = (constraints.maxWidth - totalHorizontalSpacing) / size
+
+        // Measure children
+        val placeables = measurables.map { measurable ->
+            measurable.measure(
+                constraints.copy(
+                    minWidth = itemWidth,
+                    maxWidth = itemWidth
+                )
+            )
+        }
+
+        // Row heights + spacing 반영
+        val rowHeights = IntArray(rowCount) { row ->
+            val from = row * size
+            val to = minOf(from + size, totalItems)
+            placeables.subList(from, to).maxOf { it.height }
+        }
+
+        val totalVerticalSpacing = vSpacingPx * (rowCount - 1)
+        val totalHeight = rowHeights.sum() + totalVerticalSpacing
+
+        layout(constraints.maxWidth, totalHeight) {
+            var y = 0
+            var index = 0
+
+            repeat(rowCount) { row ->
+                var x = 0
+                val rowHeight = rowHeights[row]
+
+                repeat(size) {
+                    if (index >= totalItems) return@repeat
+                    val placeable = placeables[index]
+                    placeable.placeRelative(x, y)
+                    x += itemWidth + hSpacingPx
+                    index++
+                }
+
+                y += rowHeight + vSpacingPx
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeUIState.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeUIState.kt
@@ -3,6 +3,7 @@ package com.zion830.threedollars.ui.home.data
 import com.naver.maps.geometry.LatLng
 import com.threedollar.domain.home.data.store.CategoryModel
 import com.threedollar.domain.home.request.FilterConditionsTypeModel
+import com.zion830.threedollars.ui.dialog.category.StoreCategoryItem
 
 data class HomeUIState(
     var mapPosition: LatLng= DEFAULT_LOCATION,
@@ -12,7 +13,7 @@ data class HomeUIState(
     var homeSortType: HomeSortType = HomeSortType.DISTANCE_ASC,
     var homeStoreType: HomeStoreType = HomeStoreType.ALL,
     var filterConditionsType : List<FilterConditionsTypeModel> = listOf(),
-    var selectedCategory: CategoryModel? = null
+    val selectedCategory: StoreCategoryItem? = null
 ) {
     companion object {
         val DEFAULT_LOCATION = LatLng(37.56, 126.97) // 서울

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -47,12 +47,13 @@ import com.zion830.threedollars.R
 import com.zion830.threedollars.databinding.FragmentHomeBinding
 import com.zion830.threedollars.datasource.model.v2.response.store.BossNearStoreResponse
 import com.zion830.threedollars.ui.dialog.MarketingDialog
-import com.zion830.threedollars.ui.dialog.SelectCategoryDialogFragment
+import com.zion830.threedollars.ui.dialog.category.SelectCategoryDialogFragment
 import com.zion830.threedollars.ui.home.adapter.AroundStoreMapViewRecyclerAdapter
 import com.zion830.threedollars.ui.home.viewModel.HomeViewModel
 import com.zion830.threedollars.ui.home.viewModel.SearchAddressViewModel
 import com.zion830.threedollars.ui.map.ui.NearStoreNaverMapFragment
 import com.threedollar.domain.home.data.store.UserStoreModel
+import com.zion830.threedollars.ui.dialog.category.StoreCategoryItem
 import com.zion830.threedollars.ui.storeDetail.boss.ui.BossStoreDetailActivity
 import com.zion830.threedollars.ui.storeDetail.user.ui.StoreDetailActivity
 import com.zion830.threedollars.ui.write.ui.AddStoreDetailFragment
@@ -512,7 +513,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
         }
     }
 
-    private fun collectSelectedCategory(category: CategoryModel?) {
+    private fun collectSelectedCategory(category: StoreCategoryItem?) {
         val text = category?.name ?: getString(CommonR.string.fragment_home_all_menu)
         val textColor = if (category == null) DesignSystemR.color.gray70 else DesignSystemR.color.pink
         val background = if (category == null) DesignSystemR.drawable.rect_white_radius10_stroke_gray30 else DesignSystemR.drawable.rect_white_radius10_stroke_black_fill_black

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeListViewFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeListViewFragment.kt
@@ -34,7 +34,8 @@ import com.threedollar.domain.home.request.FilterConditionsTypeModel
 import com.zion830.threedollars.DynamicLinkActivity
 import com.zion830.threedollars.core.designsystem.R as DesignSystemR
 import com.zion830.threedollars.databinding.FragmentHomeListViewBinding
-import com.zion830.threedollars.ui.dialog.SelectCategoryDialogFragment
+import com.zion830.threedollars.ui.dialog.category.SelectCategoryDialogFragment
+import com.zion830.threedollars.ui.dialog.category.StoreCategoryItem
 import com.zion830.threedollars.ui.home.adapter.AroundStoreListViewRecyclerAdapter
 import com.zion830.threedollars.ui.home.data.HomeSortType
 import com.zion830.threedollars.ui.home.data.HomeStoreType
@@ -163,7 +164,7 @@ class HomeListViewFragment : BaseFragment<FragmentHomeListViewBinding, HomeViewM
             }
     }
 
-    private fun updateCategoryView(category: CategoryModel) {
+    private fun updateCategoryView(category: StoreCategoryItem) {
         val (text, textColor, background) = getCategoryViewAttributes(category)
         binding.allMenuTextView.apply {
             this.text = text
@@ -175,8 +176,8 @@ class HomeListViewFragment : BaseFragment<FragmentHomeListViewBinding, HomeViewM
         }
     }
 
-    private fun getCategoryViewAttributes(category: CategoryModel): Triple<String, Int, Int> {
-        return if (category.categoryId.isEmpty()) {
+    private fun getCategoryViewAttributes(category: StoreCategoryItem): Triple<String, Int, Int> {
+        return if (category.id.isEmpty()) {
             Triple(
                 getString(CommonR.string.fragment_home_all_menu),
                 DesignSystemR.color.gray70,

--- a/app/src/main/java/com/zion830/threedollars/ui/splash/viewModel/SplashViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/splash/viewModel/SplashViewModel.kt
@@ -1,10 +1,6 @@
 package com.zion830.threedollars.ui.splash.viewModel
 
 import androidx.lifecycle.viewModelScope
-import com.threedollar.domain.home.data.advertisement.AdvertisementModelV2
-import com.threedollar.domain.home.repository.HomeRepository
-import com.threedollar.domain.login.data.AccessCheckModel
-import com.threedollar.domain.login.repository.LoginRepository
 import com.naver.maps.geometry.LatLng
 import com.threedollar.common.analytics.ScreenName
 import com.threedollar.common.base.BaseViewModel
@@ -12,12 +8,14 @@ import com.threedollar.common.utils.AdvertisementsPosition
 import com.threedollar.common.utils.Constants.BOSS_STORE
 import com.threedollar.common.utils.SharedPrefUtils
 import com.threedollar.common.utils.SharedPrefUtils.Companion.BOSS_FEED_BACK_LIST
+import com.threedollar.domain.home.data.advertisement.AdvertisementModelV2
+import com.threedollar.domain.home.repository.HomeRepository
+import com.threedollar.domain.login.data.AccessCheckModel
+import com.threedollar.domain.login.repository.LoginRepository
 import com.threedollar.network.request.PushInformationRequest
 import com.zion830.threedollars.GlobalApplication
 import com.zion830.threedollars.datasource.AppStatusRepository
-import com.zion830.threedollars.datasource.StoreDataSource
 import com.zion830.threedollars.datasource.model.AppUpdateDialog
-import com.zion830.threedollars.utils.LegacySharedPrefUtils
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,13 +23,11 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-import com.threedollar.common.R as CommonR
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     private val sharedPrefUtils: SharedPrefUtils,
     private val loginRepository: LoginRepository,
-    private val storeDataSource: StoreDataSource,
     private val homeRepository: HomeRepository,
     private val appStatusRepository: AppStatusRepository
 ) : BaseViewModel() {
@@ -56,15 +52,6 @@ class SplashViewModel @Inject constructor(
 
     init {
         viewModelScope.launch(coroutineExceptionHandler) {
-            storeDataSource.getCategories().collect { categories ->
-                if (categories.isSuccessful) {
-                    val categoriesModelList = categories.body()?.data ?: emptyList()
-                    LegacySharedPrefUtils.saveCategories(categoriesModelList.filter { it.classification.description == "간식류" })
-                    LegacySharedPrefUtils.saveTruckCategories(categoriesModelList.filter { it.classification.description == "식사류" })
-                } else {
-                    _msgTextId.postValue(CommonR.string.connection_failed)
-                }
-            }
             loginRepository.getFeedbackTypes(targetType = BOSS_STORE).collect {
                 if (it.ok) {
                     withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/zion830/threedollars/utils/LegacySharedPrefUtils.kt
+++ b/app/src/main/java/com/zion830/threedollars/utils/LegacySharedPrefUtils.kt
@@ -46,14 +46,6 @@ object LegacySharedPrefUtils {
 
     fun getAccessToken() = sharedPreferences.getString(ACCESS_TOKEN_KEY, null)
 
-    fun saveCategories(categoryInfo: List<CategoriesModel>) {
-        saveList(categoryInfo, CATEGORY_LIST)
-    }
-
-    fun saveTruckCategories(categoryInfo: List<CategoriesModel>) {
-        saveList(categoryInfo, TRUCK_CATEGORY_LIST)
-    }
-
     fun saveLoginType(loginType: LoginType?) = sharedPreferences.edit {
         putString(LOGIN_TYPE, loginType?.socialName)
         commit()

--- a/app/src/main/res/layout/dialog_bottom_select_category.xml
+++ b/app/src/main/res/layout/dialog_bottom_select_category.xml
@@ -90,46 +90,12 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.cardview.widget.CardView>
 
-        <TextView
-            style="@style/apple_gothic_bold.size_16dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="24dp"
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/categoryList"
             android:layout_marginTop="24dp"
-            android:text="간식"
-            android:textColor="@color/black" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/streetCategoryRecyclerView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="14dp"
-            android:layout_marginTop="12dp"
-            android:nestedScrollingEnabled="false"
-            android:overScrollMode="never"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:spanCount="4"
-            tools:listitem="@layout/item_street_category_btn" />
+            android:layout_height="wrap_content" />
 
-        <TextView
-            style="@style/apple_gothic_bold.size_16dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="24dp"
-            android:layout_marginTop="24dp"
-            android:text="음식"
-            android:textColor="@color/black" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/bossCategoryRecyclerView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="14dp"
-            android:layout_marginTop="12dp"
-            android:nestedScrollingEnabled="false"
-            android:overScrollMode="never"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:spanCount="4"
-            tools:listitem="@layout/item_street_category_btn" />
     </LinearLayout>
+
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -88,6 +88,7 @@
                     android:drawablePadding="4dp"
                     android:paddingHorizontal="10dp"
                     android:paddingVertical="8dp"
+                    android:gravity="center_vertical"
                     android:text="@string/fragment_home_all_menu"
                     app:drawableStartCompat="@drawable/ic_category"
                     app:layout_constraintStart_toStartOf="parent"

--- a/core/common/src/main/java/com/threedollar/common/ext/LifecycleOwnerExt.kt
+++ b/core/common/src/main/java/com/threedollar/common/ext/LifecycleOwnerExt.kt
@@ -1,0 +1,37 @@
+package com.threedollar.common.ext
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+fun LifecycleOwner.repeatOn(
+    state: Lifecycle.State,
+    block: suspend CoroutineScope.() -> Unit,
+): Job = lifecycleScope.launch {
+    repeatOnLifecycle(
+        state = state,
+        block = block
+    )
+}
+
+fun <T> LifecycleOwner.repeatCollectLatest(
+    flow: Flow<T>,
+    state: Lifecycle.State,
+    block: suspend (T) -> Unit,
+): Job = repeatOn(state) {
+    flow.collectLatest(block)
+}
+
+fun <T> LifecycleOwner.repeatCollect(
+    flow: Flow<T>,
+    state: Lifecycle.State,
+    block: suspend (T) -> Unit,
+): Job = repeatOn(state) {
+    flow.collect(block)
+}

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="delete">삭제</string>
     <string name="cancel">취소</string>
     <string name="close">닫기</string>
+    <string name="retry">재시도</string>
     <string name="complete">완료</string>
     <string name="more">더보기</string>
     <string name="show_all">모두보기</string>


### PR DESCRIPTION
- 기존 스플래시에서 shared preferences에 저장해서 사용하던 코드 제거
- SelectCategoryDialogFragment 노출 시 API 호출, activity-scope로 상태 유지
- 카테고리 목록 Compose migration
- 팔로업 태스크
    - TH-888 : [AOS/유저앱] 카테고리 선택 > 상단 & 아이콘 광고 미노출
    - UI/UX 개선작업


https://github.com/user-attachments/assets/2a79e061-55aa-460d-b5dd-93682fd4b758