### PR TITLE
TH-1152 홈 바텀시트 QA 대응

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         targetSdk = libs.versions.targetSdk.get().toInt()
 
         applicationId = "com.zion830.threedollars"
-        versionCode = 122
+        versionCode = 123
         versionName = project.findProperty("version_name") as String
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/zion830/threedollars/GlobalApplication.kt
+++ b/app/src/main/java/com/zion830/threedollars/GlobalApplication.kt
@@ -64,7 +64,11 @@ class GlobalApplication : Application() {
         LogManager.initialize(eventTracker)
         com.threedollar.common.analytics.SDClickLogger.initialize(eventTracker)
 
-        RequestConfiguration.Builder().setTestDeviceIds(listOf(DEVICE_ID_EMULATOR)).build()
+        MobileAds.setRequestConfiguration(
+            RequestConfiguration.Builder()
+                .setTestDeviceIds(listOf(DEVICE_ID_EMULATOR))
+                .build()
+        )
         MobileAds.initialize(this)
         KakaoSdk.init(this, BuildConfig.KAKAO_KEY)
         NaverMapSdk.getInstance(this).client =

--- a/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreview.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreview.kt
@@ -1,0 +1,60 @@
+package com.zion830.threedollars.ui.home.data
+
+import com.threedollar.common.serverdriven.model.HomeListCardModel
+import com.threedollar.common.utils.Constants.BOSS_STORE
+import com.threedollar.common.utils.Constants.USER_STORE
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+internal fun HomeListCardModel.BasicCard.storePreviewStoreIdOrNull(): Long? {
+    return link?.link.storeIdQueryOrNull()
+        ?: marker.link?.link.storeIdQueryOrNull()
+        ?: storeIdFromCardId()
+}
+
+internal fun HomeListCardModel.BasicCard.storePreviewStoreTypeOrNull(): String? {
+    return link?.link.queryValue(STORE_TYPE_QUERY)
+        ?: marker.link?.link.queryValue(STORE_TYPE_QUERY)
+        ?: storeTypeFromCardId()
+}
+
+private fun String?.storeIdQueryOrNull(): Long? {
+    return queryValue(STORE_ID_QUERY)?.toLongOrNull()
+}
+
+private fun String?.queryValue(key: String): String? {
+    if (isNullOrBlank()) return null
+
+    return runCatching {
+        URI(this).rawQuery
+            ?.split("&")
+            .orEmpty()
+            .firstNotNullOfOrNull { part ->
+                val name = part.substringBefore("=", missingDelimiterValue = "")
+                if (decodeUrl(name) != key) return@firstNotNullOfOrNull null
+
+                val value = part.substringAfter("=", missingDelimiterValue = "")
+                decodeUrl(value)
+            }
+    }.getOrNull()
+}
+
+private fun HomeListCardModel.BasicCard.storeIdFromCardId(): Long? {
+    return cardId.substringAfter(":", missingDelimiterValue = cardId).toLongOrNull()
+}
+
+private fun HomeListCardModel.BasicCard.storeTypeFromCardId(): String? {
+    return when (cardId.substringBefore(":", missingDelimiterValue = "")) {
+        "B" -> BOSS_STORE
+        "S" -> USER_STORE
+        else -> null
+    }
+}
+
+private fun decodeUrl(value: String): String {
+    return URLDecoder.decode(value, StandardCharsets.UTF_8.name())
+}
+
+private const val STORE_ID_QUERY = "storeId"
+private const val STORE_TYPE_QUERY = "storeType"

--- a/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreviewFallback.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreviewFallback.kt
@@ -1,0 +1,96 @@
+package com.zion830.threedollars.ui.home.data
+
+import com.threedollar.common.serverdriven.model.HomeListCardModel
+import com.threedollar.common.serverdriven.model.SDButtonModel
+import com.threedollar.common.serverdriven.model.SDClickLogValue
+import com.threedollar.common.serverdriven.model.SDCustomActionModel
+import com.threedollar.common.serverdriven.model.SDLinkModel
+import com.threedollar.common.serverdriven.model.SDSurfaceStyleModel
+import com.threedollar.common.serverdriven.model.SDTextModel
+import com.threedollar.common.serverdriven.model.StoreActionBarModel
+import com.threedollar.common.serverdriven.model.StoreScreenModel
+import com.threedollar.common.serverdriven.model.StoreSectionAdditionalInfosModel
+import com.threedollar.common.serverdriven.model.StoreSectionModel
+import com.threedollar.common.utils.Constants.USER_STORE
+
+internal fun HomeListCardModel.BasicCard.toFallbackStorePreviewScreen(): StoreScreenModel? {
+    val storeId = storePreviewStoreIdOrNull() ?: return null
+    val storeType = storePreviewStoreTypeOrNull() ?: USER_STORE
+    val storeName = header.title?.text.orEmpty()
+    val actionParams = mapOf(
+        "STORE_ID" to storeId.toStoreIdClickLogValue(),
+        "STORE_TYPE" to SDClickLogValue.StringValue(storeType),
+        "STORE_NAME" to SDClickLogValue.StringValue(storeName),
+        "LATITUDE" to SDClickLogValue.DoubleValue(marker.location.latitude),
+        "LONGITUDE" to SDClickLogValue.DoubleValue(marker.location.longitude),
+    )
+
+    return StoreScreenModel(
+        sections = listOf(
+            StoreSectionModel.Preview(
+                type = STORE_PREVIEW_SECTION_TYPE,
+                header = header,
+                metadata = metadata,
+                additionalInfos = StoreSectionAdditionalInfosModel(type = STORE_ADDITIONAL_INFO_TYPE),
+                actionBars = listOf(
+                    visitAction(storeId),
+                    customAction(label = "리뷰 작성", actionType = "STORE_PREVIEW_SECTION_REVIEW_WRITE", params = actionParams),
+                    customAction(label = "공유", actionType = "STORE_PREVIEW_SECTION_SHARE", params = actionParams),
+                    customAction(label = "길안내", actionType = "STORE_PREVIEW_SECTION_NAVIGATION", params = actionParams),
+                ),
+                images = images,
+                bodies = bodies,
+                style = style ?: SDSurfaceStyleModel(backgroundColor = "#FFFFFF"),
+            )
+        ),
+    )
+}
+
+private fun visitAction(storeId: Long): StoreActionBarModel {
+    return StoreActionBarModel(
+        type = ACTION_BAR_TYPE,
+        button = SDButtonModel(
+            text = fallbackText("방문 인증", fontColor = "#FFFFFF"),
+            imageAlignment = "END",
+            link = SDLinkModel(type = APP_SCHEME_LINK_TYPE, link = "/visit?storeId=$storeId"),
+        ),
+    )
+}
+
+private fun customAction(
+    label: String,
+    actionType: String,
+    params: Map<String, SDClickLogValue>,
+): StoreActionBarModel {
+    return StoreActionBarModel(
+        type = ACTION_BAR_TYPE,
+        button = SDButtonModel(
+            text = fallbackText(label),
+            customAction = SDCustomActionModel(
+                actionType = actionType,
+                extraParams = params,
+            ),
+        ),
+    )
+}
+
+private fun fallbackText(text: String, fontColor: String? = null): SDTextModel {
+    return SDTextModel(
+        text = text,
+        isHtml = false,
+        fontColor = fontColor,
+    )
+}
+
+private fun Long.toStoreIdClickLogValue(): SDClickLogValue {
+    return if (this in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
+        SDClickLogValue.IntValue(toInt())
+    } else {
+        SDClickLogValue.StringValue(toString())
+    }
+}
+
+private const val STORE_PREVIEW_SECTION_TYPE = "PREVIEW"
+private const val STORE_ADDITIONAL_INFO_TYPE = "STORE"
+private const val ACTION_BAR_TYPE = "ACTION_BAR"
+private const val APP_SCHEME_LINK_TYPE = "APP_SCHEME"

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -36,11 +36,14 @@ import com.threedollar.common.ext.addNewFragment
 import com.threedollar.common.listener.OnItemClickListener
 import com.threedollar.common.listener.OnSnapPositionChangeListener
 import com.threedollar.common.listener.SnapOnScrollListener
+import com.threedollar.common.serverdriven.ext.displayText
+import com.threedollar.common.serverdriven.ext.toServerDrivenPlainText
 import com.threedollar.common.serverdriven.model.HomeListCardModel
 import com.threedollar.common.serverdriven.model.SDClickLogValue
 import com.threedollar.common.serverdriven.model.SDCustomActionModel
 import com.threedollar.common.serverdriven.model.SDLinkModel
 import com.threedollar.common.serverdriven.model.StoreActionBarModel
+import com.threedollar.common.serverdriven.model.StoreSectionModel
 import com.threedollar.common.utils.Constants
 import com.threedollar.common.utils.Constants.BOSS_STORE
 import com.threedollar.common.utils.Constants.USER_STORE
@@ -56,6 +59,8 @@ import com.zion830.threedollars.ui.dialog.DirectionBottomDialog
 import com.zion830.threedollars.ui.dialog.MarketingDialog
 import com.zion830.threedollars.ui.dialog.category.SelectCategoryDialogFragment
 import com.zion830.threedollars.ui.home.adapter.AroundStoreMapViewRecyclerAdapter
+import com.zion830.threedollars.ui.home.data.storePreviewStoreIdOrNull
+import com.zion830.threedollars.ui.home.data.storePreviewStoreTypeOrNull
 import com.zion830.threedollars.ui.home.ui.compose.HomeBottomSheetContent
 import com.zion830.threedollars.ui.home.ui.compose.HomeFilterChipsRow
 import com.zion830.threedollars.ui.home.viewModel.HomeViewModel
@@ -285,7 +290,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
                 HomeBottomSheetContent(
                     homeListSection = homeListSection,
                     storeScreen = storeScreen,
-                    onCardClick = ::moveHomeListCardDetail,
+                    onCardClick = viewModel::selectHomeListCard,
                     onLoadNextPage = viewModel::fetchNextHomeListSection,
                     onClosePreview = viewModel::closeStorePreview,
                     onActionClick = ::handleStorePreviewAction,
@@ -496,21 +501,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
         startActivity(intent)
     }
 
-    private fun moveHomeListCardDetail(card: HomeListCardModel.BasicCard) {
-        viewModel.sendClickHomeListCard(card)
-        val route = HomeStorePreviewRoute.fromLink(
-            link = card.link?.link,
-            fallbackStoreId = card.storeIdFromCardId(),
-            fallbackStoreType = card.storeTypeFromCardId(),
-        ) ?: return
-        val intent = if (route.storeType == BOSS_STORE) {
-            BossStoreDetailActivity.getIntent(requireContext(), route.storeId.toString())
-        } else {
-            StoreDetailActivity.getIntent(requireContext(), storeId = route.storeId.toInt())
-        }
-        startActivityForResult(intent, Constants.SHOW_STORE_BY_CATEGORY)
-    }
-
     private fun moveStorePreviewDetail() {
         val route = currentStorePreviewRoute() ?: return
         val intent = if (route.storeType == BOSS_STORE) {
@@ -529,7 +519,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
         )
         val storeId = route?.storeId?.toString()
         val storeType = route?.storeType ?: USER_STORE
-        val storeName = params.stringValue("STORE_NAME") ?: currentStorePreviewTitle()
+        val storeName = params.stringValue("STORE_NAME")?.toServerDrivenPlainText() ?: currentStorePreviewTitle()
         val currentCard = currentHomeListCard()
         val latitude = params.doubleValue("LATITUDE") ?: currentCard?.marker?.location?.latitude
         val longitude = params.doubleValue("LONGITUDE") ?: currentCard?.marker?.location?.longitude
@@ -581,18 +571,18 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
         DirectionBottomDialog.getInstance(
             latitude = params.doubleValue("LATITUDE"),
             longitude = params.doubleValue("LONGITUDE"),
-            storeName = params.stringValue("STORE_NAME") ?: currentStorePreviewTitle(),
+            storeName = params.stringValue("STORE_NAME")?.toServerDrivenPlainText() ?: currentStorePreviewTitle(),
         ).show(parentFragmentManager, "")
     }
 
     private fun currentStorePreviewTitle(): String {
         return viewModel.selectedStoreScreen.value
             ?.sections
-            ?.filterIsInstance<com.threedollar.common.serverdriven.model.StoreSectionModel.Preview>()
+            ?.filterIsInstance<StoreSectionModel.Preview>()
             ?.firstOrNull()
             ?.header
             ?.title
-            ?.text
+            .displayText()
             .orEmpty()
     }
 
@@ -601,11 +591,11 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
         val markerLocation = card?.marker?.location ?: return null
         return StoreCertificationArgs(
             storeId = storeId,
-            storeName = currentStorePreviewTitle().ifBlank { card.header.title?.text.orEmpty() },
+            storeName = currentStorePreviewTitle().ifBlank { card.header.title.displayText() },
             latitude = markerLocation.latitude,
             longitude = markerLocation.longitude,
             categories = card.metadata.primary.mapNotNull { chip ->
-                val name = chip.text.text.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                val name = chip.text.displayText().takeIf { it.isNotBlank() } ?: return@mapNotNull null
                 StoreCertificationCategoryArgs(
                     name = name,
                     imageUrl = chip.image?.url.orEmpty(),
@@ -632,8 +622,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
             link = card?.link?.link,
             fallbackStoreId = fallbackStoreId
                 ?: viewModel.selectedStorePreviewStoreId.value
-                ?: card?.storeIdFromCardId(),
-            fallbackStoreType = fallbackStoreType ?: card?.storeTypeFromCardId(),
+                ?: card?.storePreviewStoreIdOrNull(),
+            fallbackStoreType = fallbackStoreType ?: card?.storePreviewStoreTypeOrNull(),
         )
     }
 
@@ -890,18 +880,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
 }
 
 private fun String.queryValue(key: String): String? = Uri.parse(this).getQueryParameter(key)
-
-private fun HomeListCardModel.BasicCard.storeIdFromCardId(): Long? {
-    return cardId.substringAfter(":", missingDelimiterValue = cardId).toLongOrNull()
-}
-
-private fun HomeListCardModel.BasicCard.storeTypeFromCardId(): String? {
-    return when (cardId.substringBefore(":", missingDelimiterValue = "")) {
-        "B" -> BOSS_STORE
-        "S" -> USER_STORE
-        else -> null
-    }
-}
 
 private fun Map<String, SDClickLogValue>.stringValue(key: String): String? {
     return when (val value = this[key]) {

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeListMarkerChipResolver.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeListMarkerChipResolver.kt
@@ -1,0 +1,23 @@
+package com.zion830.threedollars.ui.home.ui
+
+import com.threedollar.common.serverdriven.ext.displayText
+import com.threedollar.common.serverdriven.model.HomeListCardModel
+import com.threedollar.common.serverdriven.model.SDChipModel
+
+internal fun HomeListCardModel.BasicCard.markerChipForSelection(isSelected: Boolean): SDChipModel {
+    val serverChip = if (isSelected) marker.focused else marker.unfocused
+    return if (serverChip.isOpenStatusMarker()) serverChip.withoutMarkerText() else serverChip
+}
+
+private fun SDChipModel.isOpenStatusMarker(): Boolean {
+    return image == null && displayText().replace(" ", "") == OPEN_STATUS_MARKER_TEXT
+}
+
+private fun SDChipModel.withoutMarkerText(): SDChipModel {
+    return copy(
+        text = text.copy(text = "", isHtml = false),
+        additionalText = null,
+    )
+}
+
+private const val OPEN_STATUS_MARKER_TEXT = "영업중"

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeBottomSheetContent.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeBottomSheetContent.kt
@@ -1,5 +1,6 @@
 package com.zion830.threedollars.ui.home.ui.compose
 
+import android.util.Log
 import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
@@ -60,10 +61,10 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
-import androidx.core.text.HtmlCompat
+import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.LoadAdError
 import base.compose.ColorWhite
 import base.compose.Gray10
 import base.compose.Gray100
@@ -77,6 +78,7 @@ import base.compose.PretendardFontFamily
 import base.compose.dpToSp
 import coil3.compose.AsyncImage
 import com.threedollar.common.compose.utils.toColor
+import com.threedollar.common.serverdriven.ext.displayText
 import com.threedollar.common.serverdriven.model.HomeListCardHeaderModel
 import com.threedollar.common.serverdriven.model.HomeListCardMetadataModel
 import com.threedollar.common.serverdriven.model.HomeListCardModel
@@ -109,6 +111,7 @@ private val StorePreviewRootGap = 12.dp
 private val StorePreviewImageHeight = 158.dp
 private val StorePreviewReviewHeight = 58.dp
 private val StorePreviewMediaGap = 8.dp
+private const val HOME_LIST_ADMOB_TAG = "HomeListAdMob"
 
 @Composable
 fun HomeBottomSheetContent(
@@ -427,11 +430,22 @@ private fun HomeListAdMobCard() {
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 12.dp)
-            .height(250.dp),
+            .height(HomeListAdMobConfig.containerHeight)
+            .background(Color(0xFF2E2E2E)),
         factory = { context ->
             AdView(context).apply {
-                setAdSize(AdSize.MEDIUM_RECTANGLE)
+                setAdSize(HomeListAdMobConfig.adSize)
                 adUnitId = context.getString(CommonR.string.admob_list_banner)
+                setBackgroundColor(0xFF2E2E2E.toInt())
+                adListener = object : AdListener() {
+                    override fun onAdLoaded() {
+                        Log.d(HOME_LIST_ADMOB_TAG, "Home list AdMob loaded")
+                    }
+
+                    override fun onAdFailedToLoad(error: LoadAdError) {
+                        Log.d(HOME_LIST_ADMOB_TAG, "Home list AdMob failed: ${error.code} ${error.message}")
+                    }
+                }
                 loadAd(AdRequest.Builder().build())
             }
         },
@@ -649,7 +663,7 @@ private fun TitleWithBadge(
             text = title.displayText(),
             color = titleColor,
             fontFamily = PretendardFontFamily,
-            fontWeight = title?.fontWeight.toComposeFontWeight(titleWeight),
+            fontWeight = title?.fontWeight.toServerDrivenFontWeight(titleWeight),
             fontSize = dpToSp(titleSize),
             lineHeight = dpToSp(titleSize + 8),
             maxLines = maxLines,
@@ -893,7 +907,7 @@ private fun MetadataRow(
                 } else {
                     chip.text.fontColor.toColor(fallback = defaultTextColor)
                 },
-                fontWeight = chip.text.fontWeight.toComposeFontWeight(FontWeight.Normal),
+                fontWeight = chip.text.fontWeight.toServerDrivenFontWeight(FontWeight.Normal),
                 modifier = if (index == 0 && chips.size > 1) Modifier.weight(1f, fill = false) else Modifier,
             )
         }
@@ -939,7 +953,7 @@ private fun MetadataChip(
                 text = additionalText.displayText(),
                 color = textColor,
                 fontFamily = PretendardFontFamily,
-                fontWeight = additionalText.fontWeight.toComposeFontWeight(FontWeight.Normal),
+                fontWeight = additionalText.fontWeight.toServerDrivenFontWeight(FontWeight.Normal),
                 fontSize = dpToSp(14),
                 lineHeight = dpToSp(20),
                 maxLines = 1,
@@ -1025,7 +1039,7 @@ private fun BodiesRow(bodies: List<SDTextModel>) {
                     text = body.displayText(),
                     color = body.fontColor.toColor(fallback = Gray70),
                     fontFamily = PretendardFontFamily,
-                    fontWeight = body.fontWeight.toComposeFontWeight(FontWeight.Medium),
+                    fontWeight = body.fontWeight.toServerDrivenFontWeight(FontWeight.Medium),
                     fontSize = dpToSp(12),
                     lineHeight = dpToSp(18),
                     maxLines = 2,
@@ -1207,28 +1221,6 @@ private fun ServerImage(
             modifier
         },
     )
-}
-
-private fun SDTextModel?.displayText(): String {
-    val value = this?.text.orEmpty()
-    return if (this?.isHtml == true) {
-        HtmlCompat.fromHtml(value, HtmlCompat.FROM_HTML_MODE_LEGACY).toString()
-    } else {
-        value
-    }
-}
-
-private fun String?.toComposeFontWeight(fallback: FontWeight): FontWeight {
-    return when (this?.trim()?.uppercase()?.replace("-", "_")?.replace(" ", "_")) {
-        "BLACK", "900" -> FontWeight.Black
-        "EXTRA_BOLD", "EXTRABOLD", "800" -> FontWeight.ExtraBold
-        "BOLD", "700" -> FontWeight.Bold
-        "SEMI_BOLD", "SEMIBOLD", "600" -> FontWeight.SemiBold
-        "MEDIUM", "500" -> FontWeight.Medium
-        "NORMAL", "REGULAR", "400" -> FontWeight.Normal
-        "LIGHT", "300" -> FontWeight.Light
-        else -> fallback
-    }
 }
 
 private fun String?.textColorOnWhite(fallback: Color): Color {

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeFilterChips.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeFilterChips.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,7 +31,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.core.text.HtmlCompat
 import base.compose.ColorWhite
 import base.compose.Gray30
 import base.compose.Gray70
@@ -41,6 +39,7 @@ import base.compose.PretendardFontFamily
 import base.compose.dpToSp
 import coil3.compose.AsyncImage
 import com.threedollar.common.compose.utils.toColor
+import com.threedollar.common.serverdriven.ext.displayText
 import com.threedollar.common.serverdriven.model.HomeFilterCurrentCategory
 import com.threedollar.common.serverdriven.model.SDButtonModel
 import com.threedollar.common.serverdriven.model.SDChipModel
@@ -259,16 +258,6 @@ private fun HomeFilterText(text: SDTextModel) {
     )
 }
 
-@Composable
-private fun SDTextModel.displayText(): String = remember(text, isHtml) {
-    if (isHtml) {
-        HtmlCompat.fromHtml(text, HtmlCompat.FROM_HTML_MODE_COMPACT).toString()
-    } else {
-        text
-    }
-}
-
-@Composable
 private fun SDChipModel.accessibilityText(): String {
     val mainText = text.displayText()
     val additional = additionalText?.displayText()

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeListAdMobConfig.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeListAdMobConfig.kt
@@ -1,0 +1,10 @@
+package com.zion830.threedollars.ui.home.ui.compose
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.google.android.gms.ads.AdSize
+
+internal object HomeListAdMobConfig {
+    val adSize: AdSize = AdSize.BANNER
+    val containerHeight: Dp = 50.dp
+}

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeServerDrivenUiFormatters.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeServerDrivenUiFormatters.kt
@@ -1,0 +1,16 @@
+package com.zion830.threedollars.ui.home.ui.compose
+
+import androidx.compose.ui.text.font.FontWeight
+
+internal fun String?.toServerDrivenFontWeight(fallback: FontWeight): FontWeight {
+    return when (this?.trim()?.uppercase()?.replace("-", "_")?.replace(" ", "_")) {
+        "BLACK", "900" -> FontWeight.Black
+        "EXTRA_BOLD", "EXTRABOLD", "800" -> FontWeight.ExtraBold
+        "BOLD", "700" -> FontWeight.Bold
+        "SEMI_BOLD", "SEMIBOLD", "600" -> FontWeight.SemiBold
+        "MEDIUM", "500" -> FontWeight.Medium
+        "NORMAL", "REGULAR", "400" -> FontWeight.Normal
+        "LIGHT", "300" -> FontWeight.Light
+        else -> fallback
+    }
+}

--- a/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
@@ -49,6 +49,8 @@ import com.zion830.threedollars.ui.home.data.HomeListSectionQueryParamsBuilder
 import com.zion830.threedollars.ui.home.data.HomeSortType
 import com.zion830.threedollars.ui.home.data.HomeStoreType
 import com.zion830.threedollars.ui.home.data.HomeUIState
+import com.zion830.threedollars.ui.home.data.storePreviewStoreIdOrNull
+import com.zion830.threedollars.ui.home.data.toFallbackStorePreviewScreen
 import com.zion830.threedollars.utils.NaverMapUtils
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -237,7 +239,8 @@ class HomeViewModel @Inject constructor(
     fun selectHomeListCard(card: HomeListCardModel.BasicCard) {
         _selectedHomeListCardId.value = card.cardId
         card.clickLog?.let { SDClickLogger.send(it) }
-        fetchStoreScreen(card.storeIdOrNull())
+        val storeId = card.storePreviewStoreIdOrNull()
+        fetchStoreScreen(storeId, fallbackCard = card)
     }
 
     fun sendClickHomeListCard(card: HomeListCardModel.BasicCard) {
@@ -247,12 +250,18 @@ class HomeViewModel @Inject constructor(
     fun selectHomeListMarker(card: HomeListCardModel.BasicCard) {
         _selectedHomeListCardId.value = card.cardId
         card.marker.clickLog?.let { SDClickLogger.send(it) }
-        fetchStoreScreen(card.storeIdOrNull())
+        val storeId = card.storePreviewStoreIdOrNull()
+        fetchStoreScreen(storeId, fallbackCard = card)
     }
 
-    fun fetchStoreScreen(storeId: Long?) {
-        if (storeId == null) return
+    fun fetchStoreScreen(storeId: Long?, fallbackCard: HomeListCardModel.BasicCard? = null) {
+        if (storeId == null) {
+            return
+        }
         _selectedStorePreviewStoreId.value = storeId
+        fallbackCard?.toFallbackStorePreviewScreen()?.let { fallbackScreen ->
+            _selectedStoreScreen.value = fallbackScreen
+        }
         val state = uiState.value
         viewModelScope.launch(coroutineExceptionHandler) {
             screenRepository.getStoreScreen(
@@ -1021,11 +1030,4 @@ class HomeViewModel @Inject constructor(
             border = SDBorderModel(color = "#FF858F", width = 1.0),
         )
     }
-}
-
-private fun HomeListCardModel.BasicCard.storeIdOrNull(): Long? {
-    return link?.link?.substringAfter("storeId=", missingDelimiterValue = "")
-        ?.substringBefore("&")
-        ?.toLongOrNull()
-        ?: cardId.substringAfter(":", missingDelimiterValue = cardId).toLongOrNull()
 }

--- a/app/src/main/java/com/zion830/threedollars/ui/map/ui/NaverMapFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/map/ui/NaverMapFragment.kt
@@ -42,6 +42,7 @@ import com.naver.maps.map.OnMapReadyCallback
 import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
+import com.threedollar.common.serverdriven.ext.displayText
 import com.threedollar.domain.home.data.store.ContentModel
 import com.threedollar.domain.home.data.store.MarkerModel
 import com.threedollar.common.serverdriven.model.HomeListCardModel
@@ -51,6 +52,7 @@ import com.zion830.threedollars.GlobalApplication
 import com.zion830.threedollars.R
 import com.zion830.threedollars.databinding.FragmentNaverMapBinding
 import com.zion830.threedollars.ui.dialog.MarkerClickDialog
+import com.zion830.threedollars.ui.home.ui.markerChipForSelection
 import com.zion830.threedollars.utils.NaverMapUtils
 import com.zion830.threedollars.utils.NaverMapUtils.DEFAULT_DISTANCE_M
 import com.zion830.threedollars.utils.NaverMapUtils.calculateDistance
@@ -320,11 +322,7 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
     ) {
         if (markers.size <= position) return
         val marker = markers[position]
-        val chip = if (isSelected) {
-            card?.marker?.focused
-        } else {
-            card?.marker?.unfocused
-        }
+        val chip = card?.markerChipForSelection(isSelected)
         applyHomeListMarkerIcon(marker = marker, chip = chip, drawableRes = drawableRes)
         marker.map = naverMap
     }
@@ -548,9 +546,7 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
 }
 
 private fun SDChipModel.markerText(): String {
-    return listOf(text.text, additionalText?.text)
-        .filterNot { it.isNullOrBlank() }
-        .joinToString(" ")
+    return displayText()
 }
 
 private fun String?.toAndroidColor(fallback: Int): Int {

--- a/app/src/test/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreviewTest.kt
+++ b/app/src/test/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreviewTest.kt
@@ -1,0 +1,91 @@
+package com.zion830.threedollars.ui.home.data
+
+import com.threedollar.common.serverdriven.model.HomeListCardHeaderModel
+import com.threedollar.common.serverdriven.model.HomeListCardMetadataModel
+import com.threedollar.common.serverdriven.model.HomeListCardModel
+import com.threedollar.common.serverdriven.model.HomeListMarkerModel
+import com.threedollar.common.serverdriven.model.SDChipModel
+import com.threedollar.common.serverdriven.model.SDClickLogValue
+import com.threedollar.common.serverdriven.model.SDLinkModel
+import com.threedollar.common.serverdriven.model.SDLocationModel
+import com.threedollar.common.serverdriven.model.SDTextModel
+import com.threedollar.common.serverdriven.model.StoreSectionModel
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeListCardStorePreviewTest {
+
+    @Test
+    fun `store preview id resolves from marker link when card link is missing`() {
+        val card = card(
+            cardId = "home-card",
+            cardLink = null,
+            markerLink = "/storePreview?storeId=100186&storeType=USER_STORE",
+        )
+
+        assertEquals(100186L, card.storePreviewStoreIdOrNull())
+        assertEquals("USER_STORE", card.storePreviewStoreTypeOrNull())
+    }
+
+    @Test
+    fun `store preview id falls back to card id`() {
+        val card = card(
+            cardId = "S:100186",
+            cardLink = null,
+            markerLink = null,
+        )
+
+        assertEquals(100186L, card.storePreviewStoreIdOrNull())
+        assertEquals("USER_STORE", card.storePreviewStoreTypeOrNull())
+    }
+
+    @Test
+    fun `fallback store preview screen includes bottom sheet actions`() {
+        val card = card(
+            cardId = "S:100186",
+            cardLink = "/store?storeType=USER_STORE&storeId=100186",
+            markerLink = "/store_bottom_sheet?storeId=100186",
+        )
+
+        val screen = card.toFallbackStorePreviewScreen()
+        val preview = screen?.sections?.single() as? StoreSectionModel.Preview
+
+        assertNotNull(preview)
+        assertEquals("가게", preview?.header?.title?.text)
+        assertEquals("STORE", preview?.additionalInfos?.type)
+        assertEquals(4, preview?.actionBars?.size)
+        assertEquals("/visit?storeId=100186", preview?.actionBars?.get(0)?.button?.link?.link)
+        assertEquals("STORE_PREVIEW_SECTION_REVIEW_WRITE", preview?.actionBars?.get(1)?.button?.customAction?.actionType)
+        assertEquals("STORE_PREVIEW_SECTION_SHARE", preview?.actionBars?.get(2)?.button?.customAction?.actionType)
+        assertEquals("STORE_PREVIEW_SECTION_NAVIGATION", preview?.actionBars?.get(3)?.button?.customAction?.actionType)
+        assertEquals(100186, (preview?.actionBars?.get(1)?.button?.customAction?.extraParams?.get("STORE_ID") as SDClickLogValue.IntValue).value)
+        assertEquals("USER_STORE", (preview.actionBars[1].button.customAction?.extraParams?.get("STORE_TYPE") as SDClickLogValue.StringValue).value)
+        assertEquals(37.1, (preview.actionBars[3].button.customAction?.extraParams?.get("LATITUDE") as SDClickLogValue.DoubleValue).value, 0.0)
+        assertEquals(127.2, (preview.actionBars[3].button.customAction?.extraParams?.get("LONGITUDE") as SDClickLogValue.DoubleValue).value, 0.0)
+    }
+
+    private fun card(
+        cardId: String,
+        cardLink: String?,
+        markerLink: String?,
+    ): HomeListCardModel.BasicCard {
+        return HomeListCardModel.BasicCard(
+            type = "BASIC_CARD",
+            cardId = cardId,
+            header = HomeListCardHeaderModel(title = SDTextModel("가게", isHtml = false)),
+            metadata = HomeListCardMetadataModel(),
+            marker = HomeListMarkerModel(
+                focused = chip(""),
+                unfocused = chip(""),
+                location = SDLocationModel(latitude = 37.1, longitude = 127.2),
+                link = markerLink?.let { SDLinkModel(type = "APP_SCHEME", link = it) },
+            ),
+            link = cardLink?.let { SDLinkModel(type = "APP_SCHEME", link = it) },
+        )
+    }
+
+    private fun chip(text: String): SDChipModel {
+        return SDChipModel(text = SDTextModel(text = text, isHtml = false))
+    }
+}

--- a/app/src/test/java/com/zion830/threedollars/ui/home/ui/HomeListMarkerChipResolverTest.kt
+++ b/app/src/test/java/com/zion830/threedollars/ui/home/ui/HomeListMarkerChipResolverTest.kt
@@ -1,0 +1,98 @@
+package com.zion830.threedollars.ui.home.ui
+
+import com.threedollar.common.serverdriven.model.HomeListCardHeaderModel
+import com.threedollar.common.serverdriven.model.HomeListCardMetadataModel
+import com.threedollar.common.serverdriven.model.HomeListCardModel
+import com.threedollar.common.serverdriven.model.HomeListMarkerModel
+import com.threedollar.common.serverdriven.model.SDChipModel
+import com.threedollar.common.serverdriven.model.SDLocationModel
+import com.threedollar.common.serverdriven.model.SDTextModel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeListMarkerChipResolverTest {
+
+    @Test
+    fun markerChipForSelection_usesServerFocusedMarkerWhenItHasTextOtherThanOpenStatus() {
+        val card = card(
+            focused = chip("대표"),
+            secondary = listOf(chip("영업중")),
+        )
+
+        val markerChip = card.markerChipForSelection(isSelected = true)
+
+        assertEquals("대표", markerChip.text.text)
+    }
+
+    @Test
+    fun markerChipForSelection_hidesServerOpenStatusMarker() {
+        val card = card(
+            focused = chip("영업 중"),
+            secondary = listOf(chip("영업중")),
+        )
+
+        val markerChip = card.markerChipForSelection(isSelected = true)
+
+        assertEquals("", markerChip.text.text)
+        assertEquals(false, markerChip.text.isHtml)
+    }
+
+    @Test
+    fun markerChipForSelection_doesNotFallbackToOpenStatusForSelectedMarkerWhenFocusedMarkerIsBlank() {
+        val card = card(
+            focused = chip(""),
+            secondary = listOf(chip("영업중", fontColor = "#FFFFFF", fontWeight = "BOLD")),
+        )
+
+        val markerChip = card.markerChipForSelection(isSelected = true)
+
+        assertEquals("", markerChip.text.text)
+        assertEquals(false, markerChip.text.isHtml)
+    }
+
+    @Test
+    fun markerChipForSelection_doesNotFallbackForUnselectedMarker() {
+        val card = card(
+            focused = chip(""),
+            unfocused = chip(""),
+            secondary = listOf(chip("영업중")),
+        )
+
+        val markerChip = card.markerChipForSelection(isSelected = false)
+
+        assertEquals("", markerChip.text.text)
+    }
+
+    private fun card(
+        focused: SDChipModel,
+        unfocused: SDChipModel = chip(""),
+        secondary: List<SDChipModel> = emptyList(),
+    ): HomeListCardModel.BasicCard {
+        return HomeListCardModel.BasicCard(
+            type = "BASIC_CARD",
+            cardId = "S:100186",
+            header = HomeListCardHeaderModel(title = SDTextModel("가게", isHtml = false)),
+            metadata = HomeListCardMetadataModel(secondary = secondary),
+            marker = HomeListMarkerModel(
+                focused = focused,
+                unfocused = unfocused,
+                location = SDLocationModel(latitude = 37.1, longitude = 127.2),
+            ),
+        )
+    }
+
+    private fun chip(
+        text: String,
+        fontColor: String? = null,
+        fontWeight: String? = null,
+    ): SDChipModel {
+        return SDChipModel(
+            text = SDTextModel(
+                text = text,
+                isHtml = false,
+                fontColor = fontColor,
+                fontWeight = fontWeight,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/zion830/threedollars/ui/home/ui/compose/HomeListAdMobConfigTest.kt
+++ b/app/src/test/java/com/zion830/threedollars/ui/home/ui/compose/HomeListAdMobConfigTest.kt
@@ -1,0 +1,16 @@
+package com.zion830.threedollars.ui.home.ui.compose
+
+import androidx.compose.ui.unit.dp
+import com.google.android.gms.ads.AdSize
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeListAdMobConfigTest {
+
+    @Test
+    fun `home list AdMob uses banner size`() {
+        assertEquals(AdSize.BANNER.width, HomeListAdMobConfig.adSize.width)
+        assertEquals(AdSize.BANNER.height, HomeListAdMobConfig.adSize.height)
+        assertEquals(50.dp, HomeListAdMobConfig.containerHeight)
+    }
+}

--- a/app/src/test/java/com/zion830/threedollars/ui/home/ui/compose/HomeServerDrivenUiFormattersTest.kt
+++ b/app/src/test/java/com/zion830/threedollars/ui/home/ui/compose/HomeServerDrivenUiFormattersTest.kt
@@ -1,0 +1,18 @@
+package com.zion830.threedollars.ui.home.ui.compose
+
+import androidx.compose.ui.text.font.FontWeight
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeServerDrivenUiFormattersTest {
+
+    @Test
+    fun toServerDrivenFontWeight_mapsServerFontWeightAliases() {
+        assertEquals(FontWeight.Normal, "NORMAL".toServerDrivenFontWeight(FontWeight.Bold))
+        assertEquals(FontWeight.Normal, "400".toServerDrivenFontWeight(FontWeight.Bold))
+        assertEquals(FontWeight.SemiBold, "SEMI_BOLD".toServerDrivenFontWeight(FontWeight.Normal))
+        assertEquals(FontWeight.SemiBold, "600".toServerDrivenFontWeight(FontWeight.Normal))
+        assertEquals(FontWeight.Bold, "BOLD".toServerDrivenFontWeight(FontWeight.Normal))
+        assertEquals(FontWeight.Bold, "700".toServerDrivenFontWeight(FontWeight.Normal))
+    }
+}

--- a/core/common/src/main/java/com/threedollar/common/serverdriven/ext/ServerDrivenTextExt.kt
+++ b/core/common/src/main/java/com/threedollar/common/serverdriven/ext/ServerDrivenTextExt.kt
@@ -1,0 +1,55 @@
+package com.threedollar.common.serverdriven.ext
+
+import com.threedollar.common.serverdriven.model.SDChipModel
+import com.threedollar.common.serverdriven.model.SDTextModel
+
+fun SDTextModel?.displayText(): String {
+    val value = this?.text.orEmpty()
+    return if (this?.isHtml == true || value.hasHtmlTag()) {
+        value.toServerDrivenPlainText()
+    } else {
+        value
+    }
+}
+
+fun SDChipModel?.displayText(): String {
+    if (this == null) return ""
+    return listOf(text.displayText(), additionalText.displayText())
+        .filter { it.isNotBlank() }
+        .joinToString(" ")
+}
+
+fun String.toServerDrivenPlainText(): String {
+    return stripHtmlTags().decodeHtmlEntities()
+}
+
+private fun String.hasHtmlTag(): Boolean = HTML_TAG_REGEX.containsMatchIn(this)
+
+private fun String.stripHtmlTags(): String {
+    return replace(HTML_LINE_BREAK_REGEX, "\n")
+        .replace(HTML_TAG_REGEX, "")
+}
+
+private fun String.decodeHtmlEntities(): String {
+    return replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace(HTML_DECIMAL_ENTITY_REGEX) { match ->
+            match.groupValues[1].toIntOrNull()?.toCodePointString() ?: match.value
+        }
+        .replace(HTML_HEX_ENTITY_REGEX) { match ->
+            match.groupValues[1].toIntOrNull(16)?.toCodePointString() ?: match.value
+        }
+}
+
+private fun Int.toCodePointString(): String {
+    return runCatching { String(Character.toChars(this)) }.getOrDefault("")
+}
+
+private val HTML_TAG_REGEX = Regex("<[^>]+>")
+private val HTML_LINE_BREAK_REGEX = Regex("(?i)<br\\s*/?>")
+private val HTML_DECIMAL_ENTITY_REGEX = Regex("&#(\\d+);")
+private val HTML_HEX_ENTITY_REGEX = Regex("&#x([0-9a-fA-F]+);")

--- a/core/common/src/test/java/com/threedollar/common/serverdriven/ext/ServerDrivenTextExtTest.kt
+++ b/core/common/src/test/java/com/threedollar/common/serverdriven/ext/ServerDrivenTextExtTest.kt
@@ -1,0 +1,36 @@
+package com.threedollar.common.serverdriven.ext
+
+import com.threedollar.common.serverdriven.model.SDChipModel
+import com.threedollar.common.serverdriven.model.SDTextModel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ServerDrivenTextExtTest {
+
+    @Test
+    fun displayText_stripsHtmlTagsWhenTextIsHtml() {
+        val text = SDTextModel(
+            text = "<span style=\"font-size:20px; font-weight:700; color:#0F0F0F\">오소로</span>",
+            isHtml = true,
+        )
+
+        assertEquals("오소로", text.displayText())
+    }
+
+    @Test
+    fun toServerDrivenPlainText_stripsHtmlTagsEvenWithoutHtmlFlag() {
+        val text = "#<span style=\"font-size:12px; color:#5A5A5A\">요거트아이스크림</span>"
+
+        assertEquals("#요거트아이스크림", text.toServerDrivenPlainText())
+    }
+
+    @Test
+    fun chipDisplayText_joinsMainTextAndAdditionalText() {
+        val chip = SDChipModel(
+            text = SDTextModel("영업중", isHtml = false),
+            additionalText = SDTextModel("<span>1km</span>", isHtml = true),
+        )
+
+        assertEquals("영업중 1km", chip.displayText())
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096M -Dkotlin.daemon.jvm.options\="-Xmx2048M" -XX:+UseParallelGC
 android.suppressUnsupportedCompileSdk=32,34
-version_name=4.19.0
+version_name=4.20.0


### PR DESCRIPTION
## 작업 내용
- 홈 바텀시트 리스트/마커 선택 시 가게 프리뷰를 표시하도록 보완
- 방문 인증, 리뷰 작성, 공유, 길안내 액션 흐름 보정
- 서버 드리븐 텍스트/fontWeight 처리와 마커 영업중 문구 제거 처리 추가
- 홈 리스트 AdMob을 배너 사이즈로 변경
- 앱 버전 4.20.0(123) 반영

## 테스트
- ./gradlew :app:testDebugUnitTest --tests com.zion830.threedollars.ui.home.ui.compose.HomeListAdMobConfigTest --tests com.zion830.threedollars.ui.home.data.HomeListCardStorePreviewTest --tests com.zion830.threedollars.ui.home.ui.HomeListMarkerChipResolverTest --tests com.zion830.threedollars.ui.home.ui.compose.HomeServerDrivenUiFormattersTest
- ./gradlew :data:testDebugUnitTest --tests com.threedollar.data.screen.HomeBottomSheetScreenMapperTest
- ./gradlew :core:common:testDebugUnitTest