### PR TITLE
TH-1152 홈 바텀시트 QA 후속 수정

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -71,6 +71,7 @@ import com.zion830.threedollars.ui.storeDetail.boss.ui.BossStoreDetailActivity
 import com.zion830.threedollars.ui.storeDetail.user.ui.StoreCertificationActivity
 import com.zion830.threedollars.ui.storeDetail.user.ui.StoreCertificationArgs
 import com.zion830.threedollars.ui.storeDetail.user.ui.StoreCertificationCategoryArgs
+import com.zion830.threedollars.ui.storeDetail.user.ui.MoreImageActivity
 import com.zion830.threedollars.ui.storeDetail.user.ui.StoreDetailActivity
 import com.zion830.threedollars.ui.write.ui.AddStoreDetailFragment
 import com.zion830.threedollars.utils.LegacySharedPrefUtils
@@ -290,12 +291,13 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
                 HomeBottomSheetContent(
                     homeListSection = homeListSection,
                     storeScreen = storeScreen,
-                    onCardClick = viewModel::selectHomeListCard,
+                    onCardClick = ::moveHomeListCardDetail,
                     onLoadNextPage = viewModel::fetchNextHomeListSection,
                     onClosePreview = viewModel::closeStorePreview,
                     onActionClick = ::handleStorePreviewAction,
                     onFavoriteClick = ::toggleStorePreviewFavorite,
                     onStorePreviewClick = ::moveStorePreviewDetail,
+                    onAddPhotoClick = ::moveStorePreviewPhotoAdd,
                     fullListTopPx = homeBottomSheetFullListTopPx,
                     onFullListBackgroundVisibleChange = { isVisible ->
                         binding.homeFullListTopBackgroundView.isVisible = isVisible
@@ -499,6 +501,29 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
             )
         }
         startActivity(intent)
+    }
+
+    private fun moveStorePreviewPhotoAdd() {
+        val route = currentStorePreviewRoute() ?: return
+        startActivityForResult(
+            MoreImageActivity.getIntent(requireContext(), route.storeId.toInt()),
+            Constants.SHOW_STORE_BY_CATEGORY,
+        )
+    }
+
+    private fun moveHomeListCardDetail(card: HomeListCardModel.BasicCard) {
+        viewModel.sendClickHomeListCard(card)
+        val route = HomeStorePreviewRoute.fromLink(
+            link = card.link?.link,
+            fallbackStoreId = card.storePreviewStoreIdOrNull(),
+            fallbackStoreType = card.storePreviewStoreTypeOrNull(),
+        ) ?: return
+        val intent = if (route.storeType == BOSS_STORE) {
+            BossStoreDetailActivity.getIntent(requireContext(), route.storeId.toString())
+        } else {
+            StoreDetailActivity.getIntent(requireContext(), storeId = route.storeId.toInt())
+        }
+        startActivityForResult(intent, Constants.SHOW_STORE_BY_CATEGORY)
     }
 
     private fun moveStorePreviewDetail() {

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeBottomSheetContent.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeBottomSheetContent.kt
@@ -44,9 +44,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -55,6 +60,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -66,9 +72,12 @@ import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdView
 import com.google.android.gms.ads.LoadAdError
 import base.compose.ColorWhite
+import base.compose.Gray0
 import base.compose.Gray10
 import base.compose.Gray100
 import base.compose.Gray20
+import base.compose.Gray30
+import base.compose.Gray50
 import base.compose.Gray60
 import base.compose.Gray70
 import base.compose.Gray80
@@ -108,8 +117,13 @@ private val StorePreviewTitleMetadataHeight = 72.dp
 private val StorePreviewActionRowHeight = 36.dp
 private val StorePreviewHeaderActionGap = 16.dp
 private val StorePreviewRootGap = 12.dp
-private val StorePreviewImageHeight = 158.dp
-private val StorePreviewReviewHeight = 58.dp
+private val StorePreviewImageHeight = 120.dp
+private const val StorePreviewReviewMaxLines = 2
+private const val StorePreviewReviewLineHeight = 18
+private const val StorePreviewReviewVerticalPaddingValue = 11
+private val StorePreviewReviewVerticalPadding = StorePreviewReviewVerticalPaddingValue.dp
+private val StorePreviewReviewEstimatedMaxHeight =
+    (StorePreviewReviewLineHeight * StorePreviewReviewMaxLines + StorePreviewReviewVerticalPaddingValue * 2).dp
 private val StorePreviewMediaGap = 8.dp
 private const val HOME_LIST_ADMOB_TAG = "HomeListAdMob"
 
@@ -123,6 +137,7 @@ fun HomeBottomSheetContent(
     onActionClick: (StoreActionBarModel) -> Unit,
     onFavoriteClick: (Boolean) -> Unit = { _ -> },
     onStorePreviewClick: () -> Unit = {},
+    onAddPhotoClick: (() -> Unit)? = null,
     fullListTopPx: Int,
     collapsedPeekHeight: Dp = 164.dp,
     onFullListBackgroundVisibleChange: (Boolean) -> Unit = {},
@@ -335,6 +350,7 @@ fun HomeBottomSheetContent(
                     onActionClick = onActionClick,
                     onFavoriteClick = onFavoriteClick,
                     onPreviewClick = onStorePreviewClick,
+                    onAddPhotoClick = onAddPhotoClick,
                     modifier = Modifier.weight(1f),
                 )
             } else {
@@ -431,12 +447,12 @@ private fun HomeListAdMobCard() {
             .fillMaxWidth()
             .padding(vertical = 12.dp)
             .height(HomeListAdMobConfig.containerHeight)
-            .background(Color(0xFF2E2E2E)),
+            .background(ColorWhite),
         factory = { context ->
             AdView(context).apply {
                 setAdSize(HomeListAdMobConfig.adSize)
                 adUnitId = context.getString(CommonR.string.admob_list_banner)
-                setBackgroundColor(0xFF2E2E2E.toInt())
+                setBackgroundColor(android.graphics.Color.WHITE)
                 adListener = object : AdListener() {
                     override fun onAdLoaded() {
                         Log.d(HOME_LIST_ADMOB_TAG, "Home list AdMob loaded")
@@ -532,6 +548,7 @@ private fun StorePreviewContent(
     onActionClick: (StoreActionBarModel) -> Unit,
     onFavoriteClick: (Boolean) -> Unit,
     onPreviewClick: () -> Unit,
+    onAddPhotoClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     val preview = storeScreen.previewSectionOrNull()
@@ -567,7 +584,7 @@ private fun StorePreviewContent(
                     modifier = Modifier.clickable(onClick = onPreviewClick),
                     verticalArrangement = Arrangement.spacedBy(StorePreviewMediaGap),
                 ) {
-                    HomeImages(images = preview.images, listMode = false)
+                    HomeImages(images = preview.images, listMode = false, onAddPhotoClick = onAddPhotoClick)
                     BodiesRow(bodies = preview.bodies)
                 }
             }
@@ -678,6 +695,7 @@ private fun TitleWithBadge(
                     height = (image.style?.height ?: badgeDefaultSize.value.toDouble()).dp,
                 ),
                 contentScale = ContentScale.Fit,
+                drawPlaceholderBackground = false,
             )
         }
     }
@@ -967,57 +985,76 @@ private fun MetadataChip(
 private fun HomeImages(
     images: List<SDImageModel>,
     listMode: Boolean,
+    onAddPhotoClick: (() -> Unit)? = null,
 ) {
     if (images.isEmpty()) return
-    val imageHeight = if (listMode) 120.dp else StorePreviewImageHeight
-    when (images.size) {
-        1 -> ServerImage(
-            image = images.first(),
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(imageHeight)
-                .clip(RoundedCornerShape(if (listMode) 8.dp else 10.dp)),
-            contentScale = ContentScale.Crop,
-        )
-
-        2 -> if (listMode) {
-            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                images.take(2).forEach { image ->
-                    ServerImage(
-                        image = image,
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(imageHeight)
-                            .clip(RoundedCornerShape(8.dp)),
-                        contentScale = ContentScale.Crop,
-                    )
-                }
-            }
-        } else {
-            LazyRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                itemsIndexed(images, key = { index, image -> "${image.url}-$index" }) { _, image ->
-                    ServerImage(
-                        image = image,
-                        modifier = Modifier
-                            .size(StorePreviewImageHeight)
-                            .clip(RoundedCornerShape(10.dp)),
-                        contentScale = ContentScale.Crop,
-                    )
-                }
+    val cornerRadius = if (listMode) 8.dp else 10.dp
+    LazyRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        itemsIndexed(images, key = { index, image -> "${image.url}-$index" }) { _, image ->
+            ServerImage(
+                image = image,
+                modifier = Modifier
+                    .size(StorePreviewImageHeight)
+                    .clip(RoundedCornerShape(cornerRadius)),
+                contentScale = ContentScale.Crop,
+            )
+        }
+        if (onAddPhotoClick != null) {
+            item(key = "store-preview-add-photo") {
+                AddPhotoTile(onClick = onAddPhotoClick)
             }
         }
+    }
+}
 
-        else -> LazyRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-            itemsIndexed(images, key = { index, image -> "${image.url}-$index" }) { _, image ->
-                ServerImage(
-                    image = image,
-                    modifier = Modifier
-                        .width(if (listMode) 120.dp else StorePreviewImageHeight)
-                        .height(imageHeight)
-                        .clip(RoundedCornerShape(if (listMode) 8.dp else 10.dp)),
-                    contentScale = ContentScale.Crop,
+@Composable
+private fun AddPhotoTile(onClick: () -> Unit) {
+    val strokeWidth = 1.dp
+    val dashWidth = 6.dp
+    val dashGap = 4.dp
+    Box(
+        modifier = Modifier
+            .size(StorePreviewImageHeight)
+            .clip(RoundedCornerShape(10.dp))
+            .background(Gray0)
+            .drawBehind {
+                val strokePx = strokeWidth.toPx()
+                drawRoundRect(
+                    color = Gray30,
+                    topLeft = Offset(strokePx / 2f, strokePx / 2f),
+                    size = Size(size.width - strokePx, size.height - strokePx),
+                    cornerRadius = CornerRadius(10.dp.toPx(), 10.dp.toPx()),
+                    style = Stroke(
+                        width = strokePx,
+                        pathEffect = PathEffect.dashPathEffect(
+                            floatArrayOf(dashWidth.toPx(), dashGap.toPx()),
+                        ),
+                    ),
                 )
             }
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Icon(
+                painter = painterResource(DesignSystemR.drawable.ic_plus),
+                contentDescription = stringResource(CommonR.string.store_preview_photo_add),
+                tint = Gray50,
+                modifier = Modifier.size(24.dp),
+            )
+            Text(
+                text = stringResource(CommonR.string.store_preview_photo_add),
+                color = Gray50,
+                fontFamily = PretendardFontFamily,
+                fontWeight = FontWeight.Normal,
+                fontSize = dpToSp(14),
+                lineHeight = dpToSp(20),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 }
@@ -1030,10 +1067,9 @@ private fun BodiesRow(bodies: List<SDTextModel>) {
             Box(
                 modifier = Modifier
                     .then(if (bodies.size == 1) Modifier.fillParentMaxWidth() else Modifier.width(300.dp))
-                    .height(58.dp)
                     .clip(RoundedCornerShape(12.dp))
                     .background(Gray10)
-                    .padding(horizontal = 12.dp, vertical = 11.dp),
+                    .padding(horizontal = 12.dp, vertical = StorePreviewReviewVerticalPadding),
             ) {
                 Text(
                     text = body.displayText(),
@@ -1041,8 +1077,8 @@ private fun BodiesRow(bodies: List<SDTextModel>) {
                     fontFamily = PretendardFontFamily,
                     fontWeight = body.fontWeight.toServerDrivenFontWeight(FontWeight.Medium),
                     fontSize = dpToSp(12),
-                    lineHeight = dpToSp(18),
-                    maxLines = 2,
+                    lineHeight = dpToSp(StorePreviewReviewLineHeight),
+                    maxLines = StorePreviewReviewMaxLines,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -1141,9 +1177,9 @@ private fun StoreSectionModel.Preview.previewSheetHeight(): Dp {
         0.dp
     }
     val mediaHeight = when {
-        images.isNotEmpty() && bodies.isNotEmpty() -> StorePreviewImageHeight + StorePreviewMediaGap + StorePreviewReviewHeight
+        images.isNotEmpty() && bodies.isNotEmpty() -> StorePreviewImageHeight + StorePreviewMediaGap + StorePreviewReviewEstimatedMaxHeight
         images.isNotEmpty() -> StorePreviewImageHeight
-        bodies.isNotEmpty() -> StorePreviewReviewHeight
+        bodies.isNotEmpty() -> StorePreviewReviewEstimatedMaxHeight
         else -> 0.dp
     }
     val mediaBlockHeight = if (mediaHeight > 0.dp) StorePreviewRootGap + mediaHeight else 0.dp

--- a/app/src/main/java/com/zion830/threedollars/ui/storeDetail/user/ui/StoreCertificationAvailableFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/storeDetail/user/ui/StoreCertificationAvailableFragment.kt
@@ -24,6 +24,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import zion830.com.common.base.onSingleClick
 import zion830.com.common.ext.isNotNullOrEmpty
+import com.threedollar.common.R as CommonR
 
 @AndroidEntryPoint
 class StoreCertificationAvailableFragment : BaseFragment<LayoutCertificationAvailableBinding, StoreCertificationViewModel>() {
@@ -31,6 +32,8 @@ class StoreCertificationAvailableFragment : BaseFragment<LayoutCertificationAvai
     override val viewModel: StoreCertificationViewModel by viewModels()
 
     private lateinit var naverMapFragment: StoreCertificationNaverMapFragment
+
+    private var pendingVisitExists = false
 
     private val userStoreModel: UserStoreModel? by lazy {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -77,10 +80,12 @@ class StoreCertificationAvailableFragment : BaseFragment<LayoutCertificationAvai
             closeCertificationFlow(Activity.RESULT_CANCELED)
         }
         binding.layoutSuccess.onSingleClick {
+            pendingVisitExists = true
             viewModel.sendClickVisitSuccess()
             viewModel.postStoreVisit(userStoreModel?.storeId ?: -1, true)
         }
         binding.layoutFailed.onSingleClick {
+            pendingVisitExists = false
             viewModel.sendClickVisitFail()
             viewModel.postStoreVisit(userStoreModel?.storeId ?: -1, false)
         }
@@ -90,7 +95,11 @@ class StoreCertificationAvailableFragment : BaseFragment<LayoutCertificationAvai
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
                 launch {
-                    viewModel.storeVisitResult.collect {
+                    viewModel.storeVisitResult.collect { isSuccess ->
+                        if (!isSuccess) return@collect
+                        if (pendingVisitExists) {
+                            showToast(CommonR.string.add_certification_success)
+                        }
                         closeCertificationFlow(Activity.RESULT_OK)
                     }
                 }

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -155,6 +155,7 @@
     <string name="edit_store_section_info">가게 정보</string>
     <string name="edit_store_section_menu">가게 메뉴</string>
     <string name="edit_store_section_photo">가게사진 제보</string>
+    <string name="store_preview_photo_add">사진 추가</string>
     <string name="edit_store_menu_count">%d개의 제보된 메뉴가 있어요</string>
     <string name="edit_store_photo_count">%d개의 제보된 사진이 있어요</string>
     <string name="edit_store_pending_photo_count">%d장의 사진이 업로드 대기 중이에요</string>


### PR DESCRIPTION
## Summary
- TH-1194 리뷰 영역을 고정 높이 대신 텍스트 높이에 맞게 처리하고 최대 2줄로 제한했습니다.
- TH-1195 이미지 영역을 120x120으로 맞추고, 이미지가 있을 때 마지막에 `사진 추가` 타일을 노출해 사진 추가 화면으로 연결했습니다.
- TH-1196/1198/1199 대응으로 배지 placeholder, 방문 인증 실패 처리, 홈 리스트 광고 배경을 조정했습니다.
- TH-1180 기준으로 리스트 카드 클릭은 상세 화면으로 바로 이동하고, 마커 클릭에서만 프리뷰 바텀시트가 뜨도록 분리했습니다.

## Validation
- `./gradlew :app:compileDebugKotlin :app:assembleDebug`
- 에뮬레이터에서 리스트 카드 탭 시 상세 화면 이동 확인
- `logcat -b crash` crash 없음
- `git diff --check`