### PR TITLE
[TH-1152] 홈 바텀시트 QA 추가 수정

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreviewFallback.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreviewFallback.kt
@@ -13,7 +13,9 @@ import com.threedollar.common.serverdriven.model.StoreSectionAdditionalInfosMode
 import com.threedollar.common.serverdriven.model.StoreSectionModel
 import com.threedollar.common.utils.Constants.USER_STORE
 
-internal fun HomeListCardModel.BasicCard.toFallbackStorePreviewScreen(): StoreScreenModel? {
+internal fun HomeListCardModel.BasicCard.toFallbackStorePreviewScreen(
+    isSubscriber: Boolean = false,
+): StoreScreenModel? {
     val storeId = storePreviewStoreIdOrNull() ?: return null
     val storeType = storePreviewStoreTypeOrNull() ?: USER_STORE
     val storeName = header.title?.text.orEmpty()
@@ -31,7 +33,10 @@ internal fun HomeListCardModel.BasicCard.toFallbackStorePreviewScreen(): StoreSc
                 type = STORE_PREVIEW_SECTION_TYPE,
                 header = header,
                 metadata = metadata,
-                additionalInfos = StoreSectionAdditionalInfosModel(type = STORE_ADDITIONAL_INFO_TYPE),
+                additionalInfos = StoreSectionAdditionalInfosModel(
+                    type = STORE_ADDITIONAL_INFO_TYPE,
+                    isSubscriber = isSubscriber,
+                ),
                 actionBars = listOf(
                     visitAction(storeId),
                     customAction(label = "리뷰 작성", actionType = "STORE_PREVIEW_SECTION_REVIEW_WRITE", params = actionParams),
@@ -43,6 +48,24 @@ internal fun HomeListCardModel.BasicCard.toFallbackStorePreviewScreen(): StoreSc
                 style = style ?: SDSurfaceStyleModel(backgroundColor = "#FFFFFF"),
             )
         ),
+    )
+}
+
+internal fun StoreScreenModel.withStorePreviewFavoriteOverride(
+    isSubscriber: Boolean?,
+): StoreScreenModel {
+    if (isSubscriber == null) return this
+
+    return copy(
+        sections = sections.map { section ->
+            if (section is StoreSectionModel.Preview) {
+                section.copy(
+                    additionalInfos = section.additionalInfos.copy(isSubscriber = isSubscriber),
+                )
+            } else {
+                section
+            }
+        },
     )
 }
 

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -302,6 +302,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
                     onFullListBackgroundVisibleChange = { isVisible ->
                         binding.homeFullListTopBackgroundView.isVisible = isVisible
                     },
+                    onVisibleHeightChange = ::updateLocationButtonBottomMargin,
                 )
             }
         }
@@ -323,6 +324,11 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
         homeBottomSheetFullListTopPx = binding.filterComposeView.bottom
             .takeIf { it > 0 }
             ?: SizeUtils.dpToPx(188f)
+    }
+
+    private fun updateLocationButtonBottomMargin(sheetVisibleHeightPx: Int) {
+        val bottomMarginPx = sheetVisibleHeightPx + SizeUtils.dpToPx(HomeSheetLayout.LOCATION_BUTTON_GAP_FROM_SHEET_DP)
+        naverMapFragment.updateLocationButtonBottomMargin(bottomMarginPx)
     }
 
     private fun initButton() {

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeSheetLayout.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeSheetLayout.kt
@@ -3,7 +3,7 @@ package com.zion830.threedollars.ui.home.ui
 internal object HomeSheetLayout {
     // Figma shows 349dp from screen bottom; the home fragment sits above the 56dp bottom navigation.
     const val COLLAPSED_PEEK_HEIGHT_DP = 293f
-    private const val LOCATION_BUTTON_GAP_FROM_SHEET_DP = 16f
+    const val LOCATION_BUTTON_GAP_FROM_SHEET_DP = 16f
 
     const val LOCATION_BUTTON_BOTTOM_MARGIN_DP =
         COLLAPSED_PEEK_HEIGHT_DP + LOCATION_BUTTON_GAP_FROM_SHEET_DP

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeBottomSheetContent.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeBottomSheetContent.kt
@@ -170,6 +170,7 @@ fun HomeBottomSheetContent(
     fullListTopPx: Int,
     collapsedPeekHeight: Dp = HomeSheetLayout.COLLAPSED_PEEK_HEIGHT_DP.dp,
     onFullListBackgroundVisibleChange: (Boolean) -> Unit = {},
+    onVisibleHeightChange: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
@@ -376,15 +377,18 @@ fun HomeBottomSheetContent(
             settledValue == HomeSheetValue.FullList &&
             abs(sheetOffsetPx - anchors.fullListOffset) <= 1f
         val topCornerRadius = if (isFullListSettled) 0.dp else 16.dp
-        val sheetHeight = with(density) {
-            HomeSheetStateCalculator.visibleHeight(
-                containerHeightPx = containerHeightPx,
-                currentOffset = sheetOffsetPx,
-            ).toDp()
-        }
+        val sheetVisibleHeightPx = HomeSheetStateCalculator.visibleHeight(
+            containerHeightPx = containerHeightPx,
+            currentOffset = sheetOffsetPx,
+        ).roundToInt()
+        val sheetHeight = with(density) { sheetVisibleHeightPx.toDp() }
 
         LaunchedEffect(isFullListSettled) {
             onFullListBackgroundVisibleChange(isFullListSettled)
+        }
+
+        LaunchedEffect(sheetVisibleHeightPx) {
+            onVisibleHeightChange(sheetVisibleHeightPx)
         }
 
         Column(

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeBottomSheetContent.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeBottomSheetContent.kt
@@ -789,7 +789,6 @@ private fun StorePreviewTitle(
         maxLines = StorePreviewTitleMaxLines,
         badgeDefaultSize = 16.dp,
         lineBreak = LineBreak.Heading,
-        fillTitleWidth = true,
     )
 }
 
@@ -1040,7 +1039,6 @@ private fun HomeHeader(
         maxLines = 2,
         badgeDefaultSize = badgeDefaultSize,
         lineBreak = LineBreak.Heading,
-        fillTitleWidth = true,
     )
 }
 

--- a/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
@@ -238,13 +238,18 @@ class HomeViewModel @Inject constructor(
                     homeListNextCursor = section.cursor?.nextCursor?.takeIf { section.cursor?.hasMore == true }
                     if (!append) {
                         val cards = section.cards.filterIsInstance<HomeListCardModel.BasicCard>()
-                        _selectedHomeListCardId.value = if (preserveSelectedStore) {
+                        val selectedCardId = if (preserveSelectedStore) {
                             cards.selectedCardIdAfterRefresh(
                                 previousSelectedCardId = previousSelectedCardId,
                                 previousSelectedStoreId = previousSelectedStoreId,
                             )
                         } else {
                             cards.firstOrNull()?.cardId
+                        }
+                        _selectedHomeListCardId.value = selectedCardId
+                        if (preserveSelectedStore && previousSelectedStoreId != null && _selectedStoreScreen.value != null) {
+                            cards.firstOrNull { it.cardId == selectedCardId }
+                                ?.let { updateStorePreviewFromCard(previousSelectedStoreId, it) }
                         }
                     }
                     sendHomeListImpressionLogs(section.cards)
@@ -289,26 +294,20 @@ class HomeViewModel @Inject constructor(
             return
         }
         _selectedStorePreviewStoreId.value = storeId
-        fallbackCard?.toFallbackStorePreviewScreen(
+        val card = fallbackCard ?: _homeListSection.value.cards
+            .filterIsInstance<HomeListCardModel.BasicCard>()
+            .firstOrNull { it.storePreviewStoreIdOrNull() == storeId }
+        card?.let { updateStorePreviewFromCard(storeId, it) }
+    }
+
+    private fun updateStorePreviewFromCard(
+        storeId: Long,
+        card: HomeListCardModel.BasicCard,
+    ) {
+        card.toFallbackStorePreviewScreen(
             isSubscriber = storePreviewFavoriteOverrides[storeId] ?: false,
         )?.let { fallbackScreen ->
             _selectedStoreScreen.value = fallbackScreen
-        }
-        val state = uiState.value
-        viewModelScope.launch(coroutineExceptionHandler) {
-            screenRepository.getStoreScreen(
-                storeId = storeId,
-                deviceLatitude = state.userLocation.latitude,
-                deviceLongitude = state.userLocation.longitude,
-            ).collect { response ->
-                if (response.ok) {
-                    val screen = response.data ?: StoreScreenModel()
-                    _selectedStoreScreen.value = screen.withStorePreviewFavoriteOverride(storePreviewFavoriteOverrides[storeId])
-                    screen.viewLog?.let { SDClickLogger.send(it) }
-                } else {
-                    _serverError.emit(response.message)
-                }
-            }
         }
     }
 

--- a/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
@@ -30,7 +30,6 @@ import com.threedollar.common.serverdriven.model.SDSurfaceStyleModel
 import com.threedollar.common.serverdriven.model.SDTextModel
 import com.threedollar.common.serverdriven.model.StoreActionBarModel
 import com.threedollar.common.serverdriven.model.StoreScreenModel
-import com.threedollar.common.serverdriven.model.StoreSectionModel
 import com.threedollar.common.utils.AdvertisementsPosition
 import com.threedollar.domain.home.data.advertisement.AdvertisementModelV2
 import com.threedollar.domain.home.data.store.ContentModel
@@ -51,6 +50,7 @@ import com.zion830.threedollars.ui.home.data.HomeStoreType
 import com.zion830.threedollars.ui.home.data.HomeUIState
 import com.zion830.threedollars.ui.home.data.storePreviewStoreIdOrNull
 import com.zion830.threedollars.ui.home.data.toFallbackStorePreviewScreen
+import com.zion830.threedollars.ui.home.data.withStorePreviewFavoriteOverride
 import com.zion830.threedollars.utils.NaverMapUtils
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -101,6 +101,8 @@ class HomeViewModel @Inject constructor(
 
     private val _storePreviewToast = MutableSharedFlow<String>()
     val storePreviewToast: SharedFlow<String> = _storePreviewToast.asSharedFlow()
+
+    private val storePreviewFavoriteOverrides = mutableMapOf<Long, Boolean>()
 
     private val _selectedHomeListCardId = MutableStateFlow<String?>(null)
     val selectedHomeListCardId: StateFlow<String?> = _selectedHomeListCardId.asStateFlow()
@@ -287,7 +289,9 @@ class HomeViewModel @Inject constructor(
             return
         }
         _selectedStorePreviewStoreId.value = storeId
-        fallbackCard?.toFallbackStorePreviewScreen()?.let { fallbackScreen ->
+        fallbackCard?.toFallbackStorePreviewScreen(
+            isSubscriber = storePreviewFavoriteOverrides[storeId] ?: false,
+        )?.let { fallbackScreen ->
             _selectedStoreScreen.value = fallbackScreen
         }
         val state = uiState.value
@@ -299,7 +303,7 @@ class HomeViewModel @Inject constructor(
             ).collect { response ->
                 if (response.ok) {
                     val screen = response.data ?: StoreScreenModel()
-                    _selectedStoreScreen.value = screen
+                    _selectedStoreScreen.value = screen.withStorePreviewFavoriteOverride(storePreviewFavoriteOverrides[storeId])
                     screen.viewLog?.let { SDClickLogger.send(it) }
                 } else {
                     _serverError.emit(response.message)
@@ -326,7 +330,7 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch(coroutineExceptionHandler) {
             homeRepository.putFavorite(targetStoreId.toString()).collect { response ->
                 if (response.ok) {
-                    updateStorePreviewFavorite(isFavorite = true)
+                    updateStorePreviewFavorite(storeId = targetStoreId, isFavorite = true)
                     _storePreviewToast.emit("가게를 저장했어요")
                 } else {
                     _serverError.emit(response.message)
@@ -340,7 +344,7 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch(coroutineExceptionHandler) {
             homeRepository.deleteFavorite(targetStoreId.toString()).collect { response ->
                 if (response.ok) {
-                    updateStorePreviewFavorite(isFavorite = false)
+                    updateStorePreviewFavorite(storeId = targetStoreId, isFavorite = false)
                     _storePreviewToast.emit("가게 저장을 취소했어요")
                 } else {
                     _serverError.emit(response.message)
@@ -350,22 +354,15 @@ class HomeViewModel @Inject constructor(
     }
 
     fun updateSelectedStorePreviewFavorite(isFavorite: Boolean) {
-        updateStorePreviewFavorite(isFavorite)
+        updateStorePreviewFavorite(storeId = _selectedStorePreviewStoreId.value, isFavorite = isFavorite)
     }
 
-    private fun updateStorePreviewFavorite(isFavorite: Boolean) {
+    private fun updateStorePreviewFavorite(storeId: Long?, isFavorite: Boolean) {
+        storeId?.let {
+            storePreviewFavoriteOverrides[it] = isFavorite
+        }
         _selectedStoreScreen.update { screen ->
-            screen?.copy(
-                sections = screen.sections.map { section ->
-                    if (section is StoreSectionModel.Preview) {
-                        section.copy(
-                            additionalInfos = section.additionalInfos.copy(isSubscriber = isFavorite),
-                        )
-                    } else {
-                        section
-                    }
-                },
-            )
+            screen?.withStorePreviewFavoriteOverride(isFavorite)
         }
     }
 

--- a/app/src/main/java/com/zion830/threedollars/ui/map/ui/NearStoreNaverMapFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/map/ui/NearStoreNaverMapFragment.kt
@@ -25,6 +25,7 @@ class NearStoreNaverMapFragment(
     val viewModel: HomeViewModel by activityViewModels()
 
     private var isFirstLoad = true
+    private var locationButtonBottomMarginPx = SizeUtils.dpToPx(HomeSheetLayout.LOCATION_BUTTON_BOTTOM_MARGIN_DP)
 
     override fun onMapReady(map: NaverMap) {
         setIsShowOverlay(isLocationAvailable())
@@ -34,9 +35,7 @@ class NearStoreNaverMapFragment(
             map.locationTrackingMode = LocationTrackingMode.None
         }
 
-        val params = binding.btnFindLocation.layoutParams as MarginLayoutParams
-        params.setMargins(0, 0, 0, SizeUtils.dpToPx(HomeSheetLayout.LOCATION_BUTTON_BOTTOM_MARGIN_DP))
-        binding.btnFindLocation.layoutParams = params
+        applyLocationButtonBottomMargin()
 
         binding.btnFindLocation.setOnClickListener {
             onLocationButtonClicked()
@@ -58,6 +57,21 @@ class NearStoreNaverMapFragment(
             }
             isFirstLoad = false
         }
+    }
+
+    fun updateLocationButtonBottomMargin(bottomMarginPx: Int) {
+        locationButtonBottomMarginPx = bottomMarginPx
+        if (view != null) {
+            applyLocationButtonBottomMargin()
+        }
+    }
+
+    private fun applyLocationButtonBottomMargin() {
+        val params = binding.btnFindLocation.layoutParams as MarginLayoutParams
+        if (params.bottomMargin == locationButtonBottomMarginPx) return
+
+        params.bottomMargin = locationButtonBottomMarginPx
+        binding.btnFindLocation.layoutParams = params
     }
 
     fun enableLocationTracking() {

--- a/app/src/test/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreviewTest.kt
+++ b/app/src/test/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreviewTest.kt
@@ -65,6 +65,35 @@ class HomeListCardStorePreviewTest {
         assertEquals(127.2, (preview.actionBars[3].button.customAction?.extraParams?.get("LONGITUDE") as SDClickLogValue.DoubleValue).value, 0.0)
     }
 
+    @Test
+    fun `fallback store preview screen keeps local favorite state`() {
+        val card = card(
+            cardId = "S:100186",
+            cardLink = "/store?storeType=USER_STORE&storeId=100186",
+            markerLink = "/store_bottom_sheet?storeId=100186",
+        )
+
+        val screen = card.toFallbackStorePreviewScreen(isSubscriber = true)
+        val preview = screen?.sections?.single() as? StoreSectionModel.Preview
+
+        assertEquals(true, preview?.additionalInfos?.isSubscriber)
+    }
+
+    @Test
+    fun `store preview screen applies local favorite state override`() {
+        val card = card(
+            cardId = "S:100186",
+            cardLink = "/store?storeType=USER_STORE&storeId=100186",
+            markerLink = "/store_bottom_sheet?storeId=100186",
+        )
+        val screen = requireNotNull(card.toFallbackStorePreviewScreen(isSubscriber = true))
+
+        val updatedScreen = screen.withStorePreviewFavoriteOverride(isSubscriber = false)
+        val preview = updatedScreen.sections.single() as? StoreSectionModel.Preview
+
+        assertEquals(false, preview?.additionalInfos?.isSubscriber)
+    }
+
     private fun card(
         cardId: String,
         cardLink: String?,

--- a/core/network/src/main/java/com/threedollar/network/api/ServerApi.kt
+++ b/core/network/src/main/java/com/threedollar/network/api/ServerApi.kt
@@ -26,7 +26,6 @@ import com.threedollar.network.data.poll.response.PollCreateApiResponse
 import com.threedollar.network.data.poll.response.PollPolicyApiResponse
 import com.threedollar.network.data.screen.HomeFilterScreenResponse
 import com.threedollar.network.data.screen.HomeListSectionResponse
-import com.threedollar.network.data.screen.StoreScreenResponse
 import com.threedollar.network.data.screen.StoreContributorHistoriesResponse
 import com.threedollar.network.data.screen.StoreContributorScreenResponse
 import com.threedollar.network.data.store.AroundStoreResponse
@@ -229,13 +228,6 @@ interface ServerApi {
         @QueryMap dynamicParams: Map<String, String> = emptyMap(),
         @Query("cursor") cursor: String? = null,
     ): Response<BaseResponse<HomeListSectionResponse>>
-
-    @GET("/api/v2/screen/store/{storeId}")
-    suspend fun getStoreScreen(
-        @Path("storeId") storeId: Long,
-        @Header("X-Device-Latitude") deviceLatitude: Double?,
-        @Header("X-Device-Longitude") deviceLongitude: Double?,
-    ): Response<BaseResponse<StoreScreenResponse>>
 
     @GET("/api/v1/screen/store/{storeId}/contributors")
     suspend fun getStoreContributorScreen(

--- a/core/network/src/main/java/com/threedollar/network/api/ServerApi.kt
+++ b/core/network/src/main/java/com/threedollar/network/api/ServerApi.kt
@@ -230,7 +230,7 @@ interface ServerApi {
         @Query("cursor") cursor: String? = null,
     ): Response<BaseResponse<HomeListSectionResponse>>
 
-    @GET("/api/v1/screen/store/{storeId}")
+    @GET("/api/v2/screen/store/{storeId}")
     suspend fun getStoreScreen(
         @Path("storeId") storeId: Long,
         @Header("X-Device-Latitude") deviceLatitude: Double?,

--- a/core/network/src/main/java/com/threedollar/network/api/ServerApi.kt
+++ b/core/network/src/main/java/com/threedollar/network/api/ServerApi.kt
@@ -230,7 +230,7 @@ interface ServerApi {
         @Query("cursor") cursor: String? = null,
     ): Response<BaseResponse<HomeListSectionResponse>>
 
-    @GET("/api/v2/screen/store/{storeId}")
+    @GET("/api/v1/screen/store/{storeId}")
     suspend fun getStoreScreen(
         @Path("storeId") storeId: Long,
         @Header("X-Device-Latitude") deviceLatitude: Double?,

--- a/core/network/src/test/java/com/threedollar/network/api/ServerApiTest.kt
+++ b/core/network/src/test/java/com/threedollar/network/api/ServerApiTest.kt
@@ -1,20 +1,17 @@
 package com.threedollar.network.api
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import retrofit2.http.GET
 
 class ServerApiTest {
 
     @Test
-    fun getStoreScreenUsesV2PreviewStoreEndpoint() {
-        val getAnnotation = requireNotNull(
-            ServerApi::class.java
-                .declaredMethods
-                .first { it.name == "getStoreScreen" }
-                .getAnnotation(GET::class.java),
-        )
+    fun serverApiDoesNotDeclareMissingV2StorePreviewEndpoint() {
+        val paths = ServerApi::class.java
+            .declaredMethods
+            .mapNotNull { it.getAnnotation(GET::class.java)?.value }
 
-        assertEquals("/api/v2/screen/store/{storeId}", getAnnotation.value)
+        assertFalse(paths.contains("/api/v2/screen/store/{storeId}"))
     }
 }

--- a/core/network/src/test/java/com/threedollar/network/api/ServerApiTest.kt
+++ b/core/network/src/test/java/com/threedollar/network/api/ServerApiTest.kt
@@ -1,0 +1,20 @@
+package com.threedollar.network.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import retrofit2.http.GET
+
+class ServerApiTest {
+
+    @Test
+    fun getStoreScreenUsesV1ScreenStoreEndpoint() {
+        val getAnnotation = requireNotNull(
+            ServerApi::class.java
+                .declaredMethods
+                .first { it.name == "getStoreScreen" }
+                .getAnnotation(GET::class.java),
+        )
+
+        assertEquals("/api/v1/screen/store/{storeId}", getAnnotation.value)
+    }
+}

--- a/core/network/src/test/java/com/threedollar/network/api/ServerApiTest.kt
+++ b/core/network/src/test/java/com/threedollar/network/api/ServerApiTest.kt
@@ -7,7 +7,7 @@ import retrofit2.http.GET
 class ServerApiTest {
 
     @Test
-    fun getStoreScreenUsesV1ScreenStoreEndpoint() {
+    fun getStoreScreenUsesV2PreviewStoreEndpoint() {
         val getAnnotation = requireNotNull(
             ServerApi::class.java
                 .declaredMethods
@@ -15,6 +15,6 @@ class ServerApiTest {
                 .getAnnotation(GET::class.java),
         )
 
-        assertEquals("/api/v1/screen/store/{storeId}", getAnnotation.value)
+        assertEquals("/api/v2/screen/store/{storeId}", getAnnotation.value)
     }
 }

--- a/data/src/main/java/com/threedollar/data/screen/datasource/ScreenRemoteDataSource.kt
+++ b/data/src/main/java/com/threedollar/data/screen/datasource/ScreenRemoteDataSource.kt
@@ -5,7 +5,6 @@ import com.threedollar.network.data.screen.HomeFilterScreenResponse
 import com.threedollar.network.data.screen.HomeListSectionResponse
 import com.threedollar.network.data.screen.StoreContributorHistoriesResponse
 import com.threedollar.network.data.screen.StoreContributorScreenResponse
-import com.threedollar.network.data.screen.StoreScreenResponse
 import kotlinx.coroutines.flow.Flow
 
 interface ScreenRemoteDataSource {
@@ -20,12 +19,6 @@ interface ScreenRemoteDataSource {
         dynamicParams: Map<String, String>,
         cursor: String?,
     ): Flow<BaseResponse<HomeListSectionResponse>>
-
-    fun getStoreScreen(
-        storeId: Long,
-        deviceLatitude: Double?,
-        deviceLongitude: Double?,
-    ): Flow<BaseResponse<StoreScreenResponse>>
 
     fun getStoreContributorScreen(storeId: String): Flow<BaseResponse<StoreContributorScreenResponse>>
 

--- a/data/src/main/java/com/threedollar/data/screen/datasource/ScreenRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/threedollar/data/screen/datasource/ScreenRemoteDataSourceImpl.kt
@@ -6,7 +6,6 @@ import com.threedollar.network.data.screen.HomeFilterScreenResponse
 import com.threedollar.network.data.screen.HomeListSectionResponse
 import com.threedollar.network.data.screen.StoreContributorHistoriesResponse
 import com.threedollar.network.data.screen.StoreContributorScreenResponse
-import com.threedollar.network.data.screen.StoreScreenResponse
 import com.threedollar.network.util.apiResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -41,14 +40,6 @@ class ScreenRemoteDataSourceImpl @Inject constructor(
                 )
             )
         )
-    }
-
-    override fun getStoreScreen(
-        storeId: Long,
-        deviceLatitude: Double?,
-        deviceLongitude: Double?,
-    ): Flow<BaseResponse<StoreScreenResponse>> = flow {
-        emit(apiResult(serverApi.getStoreScreen(storeId, deviceLatitude, deviceLongitude)))
     }
 
     override fun getStoreContributorScreen(storeId: String): Flow<BaseResponse<StoreContributorScreenResponse>> = flow {

--- a/data/src/main/java/com/threedollar/data/screen/repository/ScreenRepositoryImpl.kt
+++ b/data/src/main/java/com/threedollar/data/screen/repository/ScreenRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.threedollar.common.serverdriven.model.HomeFilterScreenModel
 import com.threedollar.common.serverdriven.model.HomeListSectionModel
 import com.threedollar.common.serverdriven.model.SDScreenModel
 import com.threedollar.common.serverdriven.model.SDSectionModel
-import com.threedollar.common.serverdriven.model.StoreScreenModel
 import com.threedollar.data.screen.asCardsSectionModel
 import com.threedollar.data.screen.asModel
 import com.threedollar.data.screen.datasource.ScreenRemoteDataSource
@@ -42,25 +41,6 @@ class ScreenRepositoryImpl @Inject constructor(
             BaseResponse(
                 ok = it.ok,
                 data = it.data?.asModel() ?: HomeListSectionModel(),
-                message = it.message,
-                resultCode = it.resultCode,
-                error = it.error,
-            )
-        }
-
-    override fun getStoreScreen(
-        storeId: Long,
-        deviceLatitude: Double?,
-        deviceLongitude: Double?,
-    ): Flow<BaseResponse<StoreScreenModel>> =
-        screenRemoteDataSource.getStoreScreen(
-            storeId = storeId,
-            deviceLatitude = deviceLatitude,
-            deviceLongitude = deviceLongitude,
-        ).map {
-            BaseResponse(
-                ok = it.ok,
-                data = it.data?.asModel() ?: StoreScreenModel(),
                 message = it.message,
                 resultCode = it.resultCode,
                 error = it.error,

--- a/domain/src/main/java/com/threedollar/domain/screen/repository/ScreenRepository.kt
+++ b/domain/src/main/java/com/threedollar/domain/screen/repository/ScreenRepository.kt
@@ -5,7 +5,6 @@ import com.threedollar.common.serverdriven.model.HomeFilterScreenModel
 import com.threedollar.common.serverdriven.model.HomeListSectionModel
 import com.threedollar.common.serverdriven.model.SDScreenModel
 import com.threedollar.common.serverdriven.model.SDSectionModel
-import com.threedollar.common.serverdriven.model.StoreScreenModel
 import kotlinx.coroutines.flow.Flow
 
 interface ScreenRepository {
@@ -20,12 +19,6 @@ interface ScreenRepository {
         dynamicParams: Map<String, String> = emptyMap(),
         cursor: String? = null,
     ): Flow<BaseResponse<HomeListSectionModel>>
-
-    fun getStoreScreen(
-        storeId: Long,
-        deviceLatitude: Double?,
-        deviceLongitude: Double?,
-    ): Flow<BaseResponse<StoreScreenModel>>
 
     fun getStoreContributorScreen(storeId: String): Flow<BaseResponse<SDScreenModel>>
 


### PR DESCRIPTION
## Summary
- 홈 프리뷰 바텀시트 UI 높이/내위치 버튼 위치/타이틀 표시를 조정했습니다.
- 상세 화면 변경 후 홈 리스트와 프리뷰 즐겨찾기 상태가 갱신되도록 반영했습니다.
- 존재하지 않는 프리뷰 v2 API 호출을 제거하고 카드 기반 프리뷰를 사용하도록 정리했습니다.

## Test Plan
- [x] ./gradlew :core:network:testDebugUnitTest --tests com.threedollar.network.api.ServerApiTest
- [x] ./gradlew :app:testDebugUnitTest --tests com.zion830.threedollars.ui.home.data.HomeListCardStorePreviewTest
- [x] ./gradlew :app:assembleDebug