### PR TITLE
[TH-1152] 홈 화면 QA 이슈 수정

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/datasource/StoreDataSource.kt
+++ b/app/src/main/java/com/zion830/threedollars/datasource/StoreDataSource.kt
@@ -48,12 +48,12 @@ interface StoreDataSource {
     ): Response<NewReviewResponse>
 
     suspend fun editReview(
-        reviewId: Int,
+        reviewId: Long,
         editReviewRequest: EditReviewRequest,
     ): Response<NewReviewResponse>
 
     suspend fun deleteReview(
-        reviewId: Int,
+        reviewId: Long,
     ): Response<BaseResponse<String>>
 
     fun getCategories(): Flow<Response<CategoriesResponse>>

--- a/app/src/main/java/com/zion830/threedollars/datasource/StoreDataSourceImpl.kt
+++ b/app/src/main/java/com/zion830/threedollars/datasource/StoreDataSourceImpl.kt
@@ -71,12 +71,12 @@ class StoreDataSourceImpl @Inject constructor(private val newService: NewService
     ): Response<NewReviewResponse> = newService.saveReview(newReviewRequest)
 
     override suspend fun editReview(
-        reviewId: Int,
+        reviewId: Long,
         editReviewRequest: EditReviewRequest,
     ): Response<NewReviewResponse> = newService.editReview(reviewId, editReviewRequest)
 
     override suspend fun deleteReview(
-        reviewId: Int,
+        reviewId: Long,
     ): Response<BaseResponse<String>> = newService.deleteReview(reviewId)
 
     override fun getCategories() = flow { emit(newService.getCategories()) }

--- a/app/src/main/java/com/zion830/threedollars/datasource/model/v2/response/NewReviewResponse.kt
+++ b/app/src/main/java/com/zion830/threedollars/datasource/model/v2/response/NewReviewResponse.kt
@@ -20,7 +20,7 @@ data class NewReview(
     @SerializedName("rating")
     val rating: Float = 0f,
     @SerializedName("reviewId")
-    val reviewId: Int = 0,
+    val reviewId: Long = 0L,
     @SerializedName("storeId")
     val storeId: Int = 0,
     @SerializedName("updatedAt")

--- a/app/src/main/java/com/zion830/threedollars/datasource/model/v2/response/my/MyReviewResponse.kt
+++ b/app/src/main/java/com/zion830/threedollars/datasource/model/v2/response/my/MyReviewResponse.kt
@@ -23,7 +23,7 @@ data class ReviewDetail(
     @SerializedName("rating")
     val rating: Float = 0f,
     @SerializedName("reviewId")
-    val reviewId: Int = 0,
+    val reviewId: Long = 0L,
     @SerializedName("store")
     val store: StoreInfo = StoreInfo(),
     @SerializedName("storeName")

--- a/app/src/main/java/com/zion830/threedollars/datasource/model/v2/response/my/Review.kt
+++ b/app/src/main/java/com/zion830/threedollars/datasource/model/v2/response/my/Review.kt
@@ -11,7 +11,7 @@ data class Review(
     @SerializedName("rating")
     val rating: Float = 0f,
     @SerializedName("reviewId")
-    val reviewId: Int = 0,
+    val reviewId: Long = 0L,
     @SerializedName("updatedAt")
     val updatedAt: String = "",
     @SerializedName("user")

--- a/app/src/main/java/com/zion830/threedollars/network/NewServiceApi.kt
+++ b/app/src/main/java/com/zion830/threedollars/network/NewServiceApi.kt
@@ -61,13 +61,13 @@ interface NewServiceApi {
 
     @PUT("/api/v2/store/review/{reviewId}")
     suspend fun editReview(
-        @Path("reviewId") reviewId: Int,
+        @Path("reviewId") reviewId: Long,
         @Body editReviewRequest: EditReviewRequest
     ): Response<NewReviewResponse>
 
     @DELETE("/api/v2/store/review/{reviewId}")
     suspend fun deleteReview(
-        @Path("reviewId") reviewId: Int,
+        @Path("reviewId") reviewId: Long,
     ): Response<BaseResponse<String>>
 
     // 가게 검색

--- a/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreviewFallback.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeListCardStorePreviewFallback.kt
@@ -109,7 +109,7 @@ private fun Long.toStoreIdClickLogValue(): SDClickLogValue {
     return if (this in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
         SDClickLogValue.IntValue(toInt())
     } else {
-        SDClickLogValue.StringValue(toString())
+        SDClickLogValue.LongValue(this)
     }
 }
 

--- a/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeUIState.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/data/HomeUIState.kt
@@ -13,7 +13,7 @@ data class HomeUIState(
     var filterCertifiedStores: Boolean = false,
     var homeSortType: HomeSortType = HomeSortType.DISTANCE_ASC,
     var homeStoreType: HomeStoreType = HomeStoreType.ALL,
-    var filterConditionsType: List<FilterConditionsTypeModel> = listOf(FilterConditionsTypeModel.RECENT_ACTIVITY),
+    var filterConditionsType: List<FilterConditionsTypeModel> = emptyList(),
     val selectedCategory: StoreCategoryItem? = null,
     val filterSections: List<HomeScreenSection> = emptyList(),
     val radioSelection: Map<String, Int> = emptyMap(),

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -931,6 +931,7 @@ private fun Map<String, SDClickLogValue>.stringValue(key: String): String? {
     return when (val value = this[key]) {
         is SDClickLogValue.StringValue -> value.value
         is SDClickLogValue.IntValue -> value.value.toString()
+        is SDClickLogValue.LongValue -> value.value.toString()
         is SDClickLogValue.DoubleValue -> value.value.toString()
         is SDClickLogValue.BoolValue -> value.value.toString()
         SDClickLogValue.Null, null -> null
@@ -941,6 +942,7 @@ private fun Map<String, SDClickLogValue>.longValue(key: String): Long? {
     return when (val value = this[key]) {
         is SDClickLogValue.StringValue -> value.value.toLongOrNull()
         is SDClickLogValue.IntValue -> value.value.toLong()
+        is SDClickLogValue.LongValue -> value.value
         is SDClickLogValue.DoubleValue -> value.value.toLong()
         is SDClickLogValue.BoolValue, SDClickLogValue.Null, null -> null
     }
@@ -950,6 +952,7 @@ private fun Map<String, SDClickLogValue>.doubleValue(key: String): Double? {
     return when (val value = this[key]) {
         is SDClickLogValue.StringValue -> value.value.toDoubleOrNull()
         is SDClickLogValue.IntValue -> value.value.toDouble()
+        is SDClickLogValue.LongValue -> value.value.toDouble()
         is SDClickLogValue.DoubleValue -> value.value
         is SDClickLogValue.BoolValue, SDClickLogValue.Null, null -> null
     }

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeBottomSheetContent.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/compose/HomeBottomSheetContent.kt
@@ -1505,6 +1505,7 @@ private fun Map<String, SDClickLogValue>.stringValue(key: String): String? {
     return when (val value = this[key]) {
         is SDClickLogValue.StringValue -> value.value
         is SDClickLogValue.IntValue -> value.value.toString()
+        is SDClickLogValue.LongValue -> value.value.toString()
         is SDClickLogValue.DoubleValue -> value.value.toString()
         is SDClickLogValue.BoolValue -> value.value.toString()
         SDClickLogValue.Null, null -> null

--- a/app/src/test/java/com/zion830/threedollars/datasource/model/v2/response/LongReviewIdResponseTest.kt
+++ b/app/src/test/java/com/zion830/threedollars/datasource/model/v2/response/LongReviewIdResponseTest.kt
@@ -1,0 +1,66 @@
+package com.zion830.threedollars.datasource.model.v2.response
+
+import com.google.gson.Gson
+import com.zion830.threedollars.datasource.model.v2.response.my.MyReviewResponse
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LongReviewIdResponseTest {
+
+    @Test
+    fun gsonParsesLongReviewIdFromNewReviewResponse() {
+        val longReviewId = 855453324337299456L
+        val response = Gson().fromJson(
+            """
+            {
+              "data": {
+                "contents": "맛있어요",
+                "createdAt": "2026-06-22T00:00:00",
+                "rating": 5,
+                "reviewId": $longReviewId,
+                "storeId": 100186,
+                "updatedAt": "2026-06-22T00:00:00"
+              },
+              "message": "success",
+              "resultCode": "OK"
+            }
+            """.trimIndent(),
+            NewReviewResponse::class.java,
+        )
+
+        assertEquals(longReviewId, response.data.reviewId)
+    }
+
+    @Test
+    fun gsonParsesLongReviewIdFromMyReviewResponse() {
+        val longReviewId = 855453324337299456L
+        val response = Gson().fromJson(
+            """
+            {
+              "data": {
+                "contents": [
+                  {
+                    "categories": [],
+                    "contents": "맛있어요",
+                    "createdAt": "2026-06-22T00:00:00",
+                    "rating": 5,
+                    "reviewId": $longReviewId,
+                    "store": {},
+                    "storeName": "가게",
+                    "updatedAt": "2026-06-22T00:00:00",
+                    "user": {}
+                  }
+                ],
+                "nextCursor": 0,
+                "totalElements": 1
+              },
+              "message": "success",
+              "resultCode": "OK"
+            }
+            """.trimIndent(),
+            MyReviewResponse::class.java,
+        )
+
+        assertEquals(longReviewId, response.data.contents.single().reviewId)
+    }
+}

--- a/app/src/test/java/com/zion830/threedollars/ui/home/data/HomeUIStateTest.kt
+++ b/app/src/test/java/com/zion830/threedollars/ui/home/data/HomeUIStateTest.kt
@@ -1,0 +1,12 @@
+package com.zion830.threedollars.ui.home.data
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeUIStateTest {
+
+    @Test
+    fun defaultFilterConditionsAreOff() {
+        assertTrue(HomeUIState().filterConditionsType.isEmpty())
+    }
+}

--- a/core/common/src/main/java/com/threedollar/common/serverdriven/model/ServerDrivenModels.kt
+++ b/core/common/src/main/java/com/threedollar/common/serverdriven/model/ServerDrivenModels.kt
@@ -261,6 +261,10 @@ sealed interface SDClickLogValue {
         override val anyValue: Any get() = value
     }
 
+    data class LongValue(val value: Long) : SDClickLogValue {
+        override val anyValue: Any get() = value
+    }
+
     data class DoubleValue(val value: Double) : SDClickLogValue {
         override val anyValue: Any get() = value
     }

--- a/core/network/src/main/java/com/threedollar/network/data/user/MyReviewResponseV2.kt
+++ b/core/network/src/main/java/com/threedollar/network/data/user/MyReviewResponseV2.kt
@@ -29,11 +29,11 @@ data class ReviewContent(
     @SerializedName("updatedAt")
     val updatedAt: String? = "",
     @SerializedName("reviewId")
-    val reviewId: Int? = 0,
+    val reviewId: Long? = 0L,
     @SerializedName("storeId")
-    val storeId: Int? = 0,
+    val storeId: Long? = 0L,
     @SerializedName("userId")
-    val userId: Int? = 0,
+    val userId: Long? = 0L,
     @SerializedName("rating")
     val rating: Int? = 0,
     @SerializedName("contents")
@@ -73,7 +73,7 @@ data class Store(
 
 data class ReviewWriter(
     @SerializedName("userId")
-    val userId: Int? = 0,
+    val userId: Long? = 0L,
     @SerializedName("name")
     val name: String? = "",
     @SerializedName("socialType")

--- a/data/src/main/java/com/threedollar/data/screen/HomeBottomSheetScreenMapper.kt
+++ b/data/src/main/java/com/threedollar/data/screen/HomeBottomSheetScreenMapper.kt
@@ -269,7 +269,12 @@ private fun JsonElement.asClickLogValue(): SDClickLogValue {
             val number = primitive.asNumber
             val asDouble = number.toDouble()
             if (asDouble == asDouble.toLong().toDouble() && !primitive.asString.contains('.')) {
-                SDClickLogValue.IntValue(number.toInt())
+                val asLong = number.toLong()
+                if (asLong in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
+                    SDClickLogValue.IntValue(asLong.toInt())
+                } else {
+                    SDClickLogValue.LongValue(asLong)
+                }
             } else {
                 SDClickLogValue.DoubleValue(asDouble)
             }

--- a/data/src/main/java/com/threedollar/data/screen/HomeFilterScreenMapper.kt
+++ b/data/src/main/java/com/threedollar/data/screen/HomeFilterScreenMapper.kt
@@ -169,7 +169,12 @@ private fun JsonElement.asClickLogValue(): SDClickLogValue {
             val number = primitive.asNumber
             val asDouble = number.toDouble()
             if (asDouble == asDouble.toLong().toDouble() && !primitive.asString.contains('.')) {
-                SDClickLogValue.IntValue(number.toInt())
+                val asLong = number.toLong()
+                if (asLong in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
+                    SDClickLogValue.IntValue(asLong.toInt())
+                } else {
+                    SDClickLogValue.LongValue(asLong)
+                }
             } else {
                 SDClickLogValue.DoubleValue(asDouble)
             }

--- a/data/src/test/java/com/threedollar/data/screen/HomeBottomSheetScreenMapperTest.kt
+++ b/data/src/test/java/com/threedollar/data/screen/HomeBottomSheetScreenMapperTest.kt
@@ -152,6 +152,34 @@ class HomeBottomSheetScreenMapperTest {
     }
 
     @Test
+    fun homeListSectionMapper_preservesLongClickLogNumbers() {
+        val longStoreId = 855453324337299456L
+        val response = HomeListSectionResponse(
+            cards = listOf(
+                HomeListCardResponse(
+                    type = "BASIC_CARD",
+                    cardId = "S:$longStoreId",
+                    header = HomeListCardHeaderResponse(title = SDTextResponse.fromText("long id store")),
+                    marker = HomeListMarkerResponse(
+                        location = SDLocationResponse(latitude = 37.1, longitude = 127.2),
+                    ),
+                    impressionLog = SDImpressionLogResponse(
+                        eventType = "IMPRESSION",
+                        screenName = "home",
+                        objectType = "card",
+                        objectId = "store",
+                        extraParameters = mapOf("STORE_ID" to JsonPrimitive(longStoreId)),
+                    ),
+                ),
+            ),
+        )
+
+        val card = response.asModel().cards.single() as HomeListCardModel.BasicCard
+
+        assertEquals(longStoreId, card.impressionLog?.extraParameters?.get("STORE_ID")?.anyValue)
+    }
+
+    @Test
     fun homeListSectionMapper_mapsAdMobTypeAlias() {
         val response = HomeListSectionResponse(
             cards = listOf(

--- a/data/src/test/java/com/threedollar/data/screen/HomeFilterScreenMapperTest.kt
+++ b/data/src/test/java/com/threedollar/data/screen/HomeFilterScreenMapperTest.kt
@@ -1,9 +1,11 @@
 package com.threedollar.data.screen
 
+import com.google.gson.JsonPrimitive
 import com.threedollar.common.serverdriven.model.HomeFilterBar
 import com.threedollar.common.serverdriven.model.HomeScreenSection
 import com.threedollar.network.data.screen.HomeFilterBarResponse
 import com.threedollar.network.data.screen.HomeFilterChipResponse
+import com.threedollar.network.data.screen.HomeFilterClickLogResponse
 import com.threedollar.network.data.screen.HomeFilterImageResponse
 import com.threedollar.network.data.screen.HomeFilterImageStyleResponse
 import com.threedollar.network.data.screen.HomeFilterScreenResponse
@@ -55,5 +57,36 @@ class HomeFilterScreenMapperTest {
         assertEquals("NEW", categoryBar.categoriesFilter.additionalText?.text)
         assertEquals(18.0, categoryBar.categoriesFilter.image?.style?.width)
         assertEquals(18.0, categoryBar.categoriesFilter.image?.style?.height)
+    }
+
+    @Test
+    fun homeFilterMapper_preservesLongClickLogNumbers() {
+        val longStoreId = 855453324337299456L
+        val response = HomeFilterScreenResponse(
+            sections = listOf(
+                HomeFilterSectionResponse(
+                    type = "HOME_FILTER",
+                    bars = listOf(
+                        HomeFilterBarResponse(
+                            type = "CATEGORY_BAR",
+                            categoriesFilter = HomeFilterChipResponse(
+                                text = HomeFilterTextResponse(text = "음식 종류"),
+                            ),
+                            categoriesFilterClickLog = HomeFilterClickLogResponse(
+                                screenName = "home",
+                                objectType = "filter",
+                                objectId = "category",
+                                extraParameters = mapOf("STORE_ID" to JsonPrimitive(longStoreId)),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val section = response.asModel().sections.single() as HomeScreenSection.HomeFilterSectionModel
+        val categoryBar = section.bars.single() as HomeFilterBar.CategoryBar
+
+        assertEquals(longStoreId, categoryBar.categoriesFilterClickLog?.extraParameters?.get("STORE_ID")?.anyValue)
     }
 }

--- a/data/src/test/java/com/threedollar/data/user/MyReviewResponseV2Test.kt
+++ b/data/src/test/java/com/threedollar/data/user/MyReviewResponseV2Test.kt
@@ -1,0 +1,49 @@
+package com.threedollar.data.user
+
+import com.google.gson.Gson
+import com.threedollar.network.data.user.MyReviewResponseV2
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MyReviewResponseV2Test {
+
+    @Test
+    fun gsonParsesLongReviewIds() {
+        val longReviewId = 855453324337299456L
+        val response = Gson().fromJson(
+            """
+            {
+              "contents": [
+                {
+                  "review": {
+                    "reviewId": $longReviewId,
+                    "storeId": $longReviewId,
+                    "userId": $longReviewId,
+                    "rating": 5,
+                    "contents": "맛있어요"
+                  },
+                  "store": {
+                    "storeId": "$longReviewId"
+                  },
+                  "reviewWriter": {
+                    "userId": $longReviewId
+                  }
+                }
+              ],
+              "cursor": {
+                "nextCursor": null,
+                "hasMore": false
+              }
+            }
+            """.trimIndent(),
+            MyReviewResponseV2::class.java,
+        )
+
+        val content = response.contents.single()
+
+        assertEquals(longReviewId, content.review.reviewId)
+        assertEquals(longReviewId, content.review.storeId)
+        assertEquals(longReviewId, content.review.userId)
+        assertEquals(longReviewId, content.reviewWriter.userId)
+    }
+}


### PR DESCRIPTION
## 작업 내용
- TH-1152 하위 이슈 및 추가 QA 이슈 반영
- 홈 프리뷰 바텀시트 UI/동작 보정
- 상세 화면 변경 후 홈 리스트/프리뷰 상태 반영
- TH-1208 최근 활동 필터 기본값 OFF 반영
- TH-1209 64bit 리뷰 ID 및 서버드리븐 숫자 파라미터 처리

## 검증
- ./gradlew :data:testDebugUnitTest --tests com.threedollar.data.user.MyReviewResponseV2Test --tests com.threedollar.data.screen.HomeBottomSheetScreenMapperTest.homeListSectionMapper_preservesLongClickLogNumbers --tests com.threedollar.data.screen.HomeFilterScreenMapperTest.homeFilterMapper_preservesLongClickLogNumbers :app:testDebugUnitTest --tests com.zion830.threedollars.datasource.model.v2.response.LongReviewIdResponseTest
- ./gradlew :app:assembleDebug