### PR TITLE
TH-811 : 투표 카드 광고 노출 위치를 exposureIndex 기준으로 적용

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/ui/community/CommunityFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/community/CommunityFragment.kt
@@ -214,10 +214,7 @@ class CommunityFragment : BaseFragment<FragmentCommunityBinding, CommunityViewMo
                 launch {
                     viewModel.pollItems.collect {
                         if (it.isEmpty()) return@collect
-                        pollItems.clear()
-                        pollItems.addAll(it.map { poll -> PollListData.Poll(poll) })
-                        injectAdvertisement()
-                        pollAdapter.submitList(pollItems.toList())
+                        submitPollList(it.map { poll -> PollListData.Poll(poll) })
                     }
                 }
                 launch {
@@ -228,7 +225,6 @@ class CommunityFragment : BaseFragment<FragmentCommunityBinding, CommunityViewMo
                         pollItems[pollItems.indexOfFirst { pollListData -> pollListData.isSelectPoll(pollId) }] =
                             PollListData.Poll(selectedPoll(selectPoll.pollItem, optionId))
                         pollAdapter.submitList(pollItems.toList())
-                        pollAdapter.notifyDataSetChanged()
                     }
                 }
                 launch {
@@ -261,28 +257,37 @@ class CommunityFragment : BaseFragment<FragmentCommunityBinding, CommunityViewMo
                     viewModel.advertisements.collect {
                         advertisementModelV2 = it.firstOrNull()
                         if (pollItems.isEmpty()) return@collect
-                        pollItems.removeAll { pollListData -> pollListData is PollListData.Ad }
-                        injectAdvertisement()
-                        pollAdapter.submitList(pollItems.toList())
+                        submitPollList(pollItems.filterIsInstance<PollListData.Poll>())
                     }
                 }
             }
         }
     }
 
-    /**
-     * 광고 응답의 [AdvertisementModelV2.MetaData.exposureIndex] 위치에 광고 카드를 끼워 넣는다.
-     * 노출 순서가 음수면 광고를 노출하지 않고, 투표 목록 길이를 넘어서면 마지막에 배치한다.
-     */
-    private fun injectAdvertisement() {
-        val advertisement = advertisementModelV2 ?: return
-        val exposureIndex = advertisement.metadata.exposureIndex
-        if (exposureIndex < 0) return
+    private fun submitPollList(polls: List<PollListData.Poll>) {
+        pollItems.clear()
+        pollItems.addAll(advertisementModelV2?.let { polls.injectAd(it) } ?: polls)
+        pollAdapter.submitList(pollItems.toList())
+    }
 
-        if (exposureIndex > pollItems.lastIndex) {
-            pollItems.add(PollListData.Ad(advertisement))
-        } else {
-            pollItems.add(exposureIndex, PollListData.Ad(advertisement))
+    private fun List<PollListData.Poll>.injectAd(
+        target: AdvertisementModelV2
+    ): List<PollListData> {
+        val originList = this
+        val targetIndex = target.metadata.exposureIndex
+
+        if (targetIndex < 0) {
+            return this
+        }
+
+        return buildList(originList.size + 1) {
+            addAll(originList)
+
+            if (targetIndex > lastIndex) {
+                add(PollListData.Ad(target))
+            } else {
+                add(targetIndex, PollListData.Ad(target))
+            }
         }
     }
 

--- a/app/src/main/java/com/zion830/threedollars/ui/community/CommunityFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/community/CommunityFragment.kt
@@ -214,12 +214,10 @@ class CommunityFragment : BaseFragment<FragmentCommunityBinding, CommunityViewMo
                 launch {
                     viewModel.pollItems.collect {
                         if (it.isEmpty()) return@collect
-                        pollItems.addAll(it.toList().map { poll -> PollListData.Poll(poll) })
-                        advertisementModelV2?.let { advertisement ->
-                            if (pollItems.size > 3) pollItems.add(2, PollListData.Ad(advertisement))
-                            else pollItems.add(PollListData.Ad(advertisement))
-                        }
-                        pollAdapter.submitList(pollItems)
+                        pollItems.clear()
+                        pollItems.addAll(it.map { poll -> PollListData.Poll(poll) })
+                        injectAdvertisement()
+                        pollAdapter.submitList(pollItems.toList())
                     }
                 }
                 launch {
@@ -229,7 +227,7 @@ class CommunityFragment : BaseFragment<FragmentCommunityBinding, CommunityViewMo
                         val selectPoll = pollItems.find { pollListData -> pollListData.isSelectPoll(pollId) } as? PollListData.Poll ?: return@collect
                         pollItems[pollItems.indexOfFirst { pollListData -> pollListData.isSelectPoll(pollId) }] =
                             PollListData.Poll(selectedPoll(selectPoll.pollItem, optionId))
-                        pollAdapter.submitList(pollItems)
+                        pollAdapter.submitList(pollItems.toList())
                         pollAdapter.notifyDataSetChanged()
                     }
                 }
@@ -262,9 +260,29 @@ class CommunityFragment : BaseFragment<FragmentCommunityBinding, CommunityViewMo
                 launch {
                     viewModel.advertisements.collect {
                         advertisementModelV2 = it.firstOrNull()
+                        if (pollItems.isEmpty()) return@collect
+                        pollItems.removeAll { pollListData -> pollListData is PollListData.Ad }
+                        injectAdvertisement()
+                        pollAdapter.submitList(pollItems.toList())
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * 광고 응답의 [AdvertisementModelV2.MetaData.exposureIndex] 위치에 광고 카드를 끼워 넣는다.
+     * 노출 순서가 음수면 광고를 노출하지 않고, 투표 목록 길이를 넘어서면 마지막에 배치한다.
+     */
+    private fun injectAdvertisement() {
+        val advertisement = advertisementModelV2 ?: return
+        val exposureIndex = advertisement.metadata.exposureIndex
+        if (exposureIndex < 0) return
+
+        if (exposureIndex > pollItems.lastIndex) {
+            pollItems.add(PollListData.Ad(advertisement))
+        } else {
+            pollItems.add(exposureIndex, PollListData.Ad(advertisement))
         }
     }
 


### PR DESCRIPTION
## 원인

커뮤니티 탭 투표 섹션에서 광고 카드를 리스트에 끼워 넣을 때 서버 응답의 `exposureIndex`를 전혀 참조하지 않고 인덱스를 하드코딩하고 있었습니다.

**문제 코드:** `CommunityFragment.kt` — `initFlow()` (기존 218-221행)

```kotlin
advertisementModelV2?.let { advertisement ->
    if (pollItems.size > 3) pollItems.add(2, PollListData.Ad(advertisement))
    else pollItems.add(PollListData.Ad(advertisement))
}
```

"항상 4번째" 증상의 직접 원인은 `else` 분기입니다. 투표 카드가 3개인 경우가 많은데 이때 `size > 3`이 false가 되어 광고가 **리스트 맨 뒤에 append** → 투표 3개 + 광고 = 항상 4번째가 됩니다.

데이터 자체는 정상적으로 UI까지 도달하고 있었습니다.
- DTO: `AdvertisementResponse.kt` — `metadata.exposureIndex`
- 도메인: `domain/community/data/AdvertisementModelV2.kt` — `MetaData(exposureIndex: Int)`
- 매퍼: `CommunityMapper.kt` — `exposureIndex = metadata?.exposureIndex ?: 0`

즉 **화면단에서 값을 쓰지 않은 것**이 유일한 문제였습니다.

함께 발견된 같은 코드 블록의 결함 2가지도 수정했습니다.
1. 광고 응답(`advertisements`)이 투표 목록(`pollItems`)보다 **늦게 도착하면 광고가 아예 노출되지 않음** — 광고 수신 시 리스트를 다시 만들지 않았음
2. `pollItems`를 `clear()` 없이 `addAll` 하고 `submitList()`에 **동일한 mutable 인스턴스**를 넘겨, 재수신 시 항목이 중복 누적되고 `ListAdapter`의 diff가 계산되지 않음

## 재현 경로

1. 커뮤니티 탭 진입
2. 투표 섹션의 광고 카드 위치 확인
3. 실제 결과: 서버가 내려준 `exposureIndex` 값과 무관하게 항상 4번째(투표 3개일 때) 또는 3번째(투표 4개 이상일 때)에 노출
4. 기대 결과: 응답의 `exposureIndex` 위치에 노출

## 수정 방향

iOS `CommunityPollListCellViewModel.swift`의 `updateDataSource()`와 동일하게 `exposureIndex`를 사용하도록 맞췄습니다. 다만 iOS는 `insert(at:)`에 상한 클램프가 없어 인덱스가 리스트 길이를 넘으면 크래시 위험이 있어, 프로젝트 내 기존 구현인 `SelectCategoryViewModel.injectAd()`의 방어 패턴(음수 가드 + 범위 초과 시 append)을 따랐습니다.

**수정 내용:**
- `CommunityFragment.kt`: `List<PollListData.Poll>.injectAd(target)` 추가 — `exposureIndex` 위치에 광고 삽입, 음수면 미노출, 목록 길이 초과 시 마지막에 배치. 기존 `SelectCategoryViewModel.injectAd()`와 동일한 시그니처/구현 형태(순수 함수 + `buildList`)를 따릅니다.
- `CommunityFragment.kt`: `submitPollList(polls)` 추가 — 투표 목록 재구성과 `submitList()` 호출을 한 곳으로 모아, 투표 수신·광고 수신 두 경로가 같은 코드를 타도록 정리
- `CommunityFragment.kt`: 광고 수신 시에도 리스트를 다시 만들어 도착 순서와 무관하게 반영
- `CommunityFragment.kt`: `submitList()`에 `toList()` 복사본 전달. 이에 따라 기존에 diff가 계산되지 않아 우회로 붙어 있던 `notifyDataSetChanged()` 제거

## 검증

- ✅ `./gradlew :app:assembleDebug` BUILD SUCCESSFUL
- ✅ **에뮬레이터 Before/After 검증 PASS** (Medium_Phone_API_36.1 / Android 16)

| | exposureIndex | 광고 위치 | 판정 |
|---|---|---|---|
| Before (`develop`) | 0 | 4번째(맨 뒤) | 값 무시 — 티켓 증상 재현 |
| After (본 브랜치) | 0 | 1번째 | 값 반영 |
| After (본 브랜치) | 2 | 3번째 | 값 반영 |

투표는 dev 서버 실제 데이터 3건(`22`, `팥붕 vs 슈붕`, `내가 정상 님들이 비정상`)입니다. Before가 맨 뒤로 간 것은 투표가 3개라 `size > 3`이 false가 되어 `else` 분기(append)를 탄 결과로, 위 원인 분석과 일치합니다.

`exposureIndex = 2` 케이스는 가로 캐러셀이라 스크린샷만으로는 좌우 카드 판별이 애매해서, `uiautomator dump`로 카드를 한 칸씩 이동하며 순서를 확정했습니다. 결과는 `[22, 팥붕vs슈붕, 광고, 내가정상]`으로 광고가 index 2입니다.

### 에뮬레이터 검증 스크린샷

| Before (develop) — index 0인데 맨 뒤 | After — index 0 → 첫 번째 | After — index 2 → 세 번째 |
|:---:|:---:|:---:|
| <img src="https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/download/verification-assets/TH-811-before-idx0.png" width="260"> | <img src="https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/download/verification-assets/TH-811-after-idx0.png" width="260"> | <img src="https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/download/verification-assets/TH-811-after-idx2.png" width="260"> |

**검증 환경 제약 (읽어주세요):**
- dev 서버가 `POLL_CARD` 구좌에 광고를 내려주지 않아(`advertisements: []`) **광고 데이터는 Proxyman scripting rule로 주입한 합성 데이터**입니다. 실제 운영 광고로 검증한 것이 아닙니다. `exposureIndex`도 같은 rule로 제어했습니다.
- 앱은 Proxyman Reverse Proxy(`:9091`)를 거쳐 dev 서버에 붙였습니다. AVD가 Google Play 이미지라 `adb root`가 불가하고 앱에 debug `network_security_config`가 없어 CA 설치 방식의 HTTPS 가로채기는 쓸 수 없었습니다.
- 소셜 로그인을 자동화할 수 없어 스플래시의 `GET /api/v4/my/user` 401 응답만 200으로 바꿔 `MainActivity`까지 진입시켰습니다. 커뮤니티 API(`poll-categories`, `polls`, `advertisements`)는 인증 없이도 200이라 **화면에 보이는 투표 데이터는 실제 dev 서버 응답**입니다.

**미검증 항목:**
- 리스트 중복 누적 수정: 커뮤니티 탭을 벗어나면 Fragment가 재생성되며 `pollItems` 필드도 새로 만들어져, 탭 전환만으로는 재현되지 않을 가능성이 큽니다. 재현 경로를 특정하지 못해 확인하지 못했습니다.
- `exposureIndex`가 음수이거나 목록 길이를 초과하는 경우의 동작(코드상 가드는 있으나 화면 검증은 하지 않았습니다).

## 영향 범위

- 커뮤니티 탭 투표 섹션(`POLL_CARD` 광고 구좌)에 한정됩니다. 전체 투표 목록 화면(`PollListActivity`)에는 원래 광고 삽입 로직이 없습니다.
- **리스크:** 낮음 (단일 Fragment의 리스트 구성 로직)
- 참고: 홈 화면에도 동일하게 `exposureIndex`를 무시하고 하드코딩된 위치를 쓰는 곳이 있습니다 (`HomeListViewFragment.kt` 인덱스 2, `HomeFragment.kt` 인덱스 1). 다른 광고 구좌(`MAIN_PAGE_CARD`, `STORE_LIST`)이고 이번 티켓 범위 밖이라 건드리지 않았습니다. 별도 티켓으로 다루면 좋겠습니다.

## 관련 이슈

- Jira: TH-811
