### PR TITLE
TH-821 : 세션 만료 시 안내 후 로그인 화면으로 이동하도록 수정

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/GlobalApplication.kt
+++ b/app/src/main/java/com/zion830/threedollars/GlobalApplication.kt
@@ -89,13 +89,7 @@ class GlobalApplication : Application() {
         observeSessionExpired()
     }
 
-    /**
-     * 세션 만료(401)를 프로세스 단위로 관찰한다.
-     *
-     * 딥링크/푸시로 진입한 화면은 [MainActivity]가 아닐 수 있어 화면별로 관찰하면 누락된다.
-     * 이벤트는 로그인에 성공해 [MainActivity]에 진입할 때 초기화되므로,
-     * 세션이 만료된 동안 요청이 여러 번 실패해도 로그인 화면으로 한 번만 이동한다.
-     */
+    // 딥링크/푸시 진입 화면은 MainActivity가 아닐 수 있어 세션 만료(401)는 프로세스 단위로 관찰한다.
     private fun observeSessionExpired() {
         applicationScope.launch {
             GlobalEvent.logoutEvent.collect { isSessionExpired ->

--- a/app/src/main/java/com/zion830/threedollars/GlobalApplication.kt
+++ b/app/src/main/java/com/zion830/threedollars/GlobalApplication.kt
@@ -15,9 +15,15 @@ import com.threedollar.domain.home.data.advertisement.AdvertisementModelV2
 import com.kakao.sdk.common.KakaoSdk
 import com.naver.maps.map.NaverMapSdk
 import com.threedollar.common.analytics.LogManager
+import com.threedollar.common.utils.GlobalEvent
 import com.zion830.threedollars.datasource.model.LoginType
+import com.zion830.threedollars.ui.login.ui.LoginActivity
 import com.zion830.threedollars.utils.LegacySharedPrefUtils
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 @HiltAndroidApp
 class GlobalApplication : Application() {
@@ -56,6 +62,8 @@ class GlobalApplication : Application() {
         }
     }
 
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
     override fun onCreate() {
         super.onCreate()
         instance = this
@@ -77,5 +85,30 @@ class GlobalApplication : Application() {
         if (isLoggedIn) {
             loginPlatform = LoginType.of(LegacySharedPrefUtils.getLoginType())
         }
+
+        observeSessionExpired()
+    }
+
+    /**
+     * 세션 만료(401)를 프로세스 단위로 관찰한다.
+     *
+     * 딥링크/푸시로 진입한 화면은 [MainActivity]가 아닐 수 있어 화면별로 관찰하면 누락된다.
+     * 이벤트는 로그인에 성공해 [MainActivity]에 진입할 때 초기화되므로,
+     * 세션이 만료된 동안 요청이 여러 번 실패해도 로그인 화면으로 한 번만 이동한다.
+     */
+    private fun observeSessionExpired() {
+        applicationScope.launch {
+            GlobalEvent.logoutEvent.collect { isSessionExpired ->
+                if (isSessionExpired) {
+                    moveToLoginBySessionExpired()
+                }
+            }
+        }
+    }
+
+    private fun moveToLoginBySessionExpired() {
+        LegacySharedPrefUtils.clearUserInfo()
+        loginPlatform = LoginType.NONE
+        startActivity(LoginActivity.getSessionExpiredIntent(this))
     }
 }

--- a/app/src/main/java/com/zion830/threedollars/MainActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/MainActivity.kt
@@ -31,7 +31,6 @@ import com.threedollar.common.utils.GlobalEvent
 import com.threedollar.common.utils.SharedPrefUtils
 import com.zion830.threedollars.databinding.ActivityHomeBinding
 import com.zion830.threedollars.ui.popup.PopupViewModel
-import com.zion830.threedollars.ui.splash.ui.SplashActivity
 import com.zion830.threedollars.ui.webview.WebActivity
 import com.zion830.threedollars.utils.isGpsAvailable
 import com.zion830.threedollars.utils.isLocationAvailable
@@ -57,6 +56,8 @@ class MainActivity : BaseActivity<ActivityHomeBinding, UserInfoViewModel>({ Acti
 
     override fun initView() {
         setDarkSystemBars()
+        // 정상적으로 메인에 진입했으므로 다음 세션 만료를 다시 감지할 수 있도록 초기화한다.
+        GlobalEvent.resetLogoutEvent()
         fusedLocationProviderClient =
             LocationServices.getFusedLocationProviderClient(this)
         if (isLocationAvailable() && isGpsAvailable()) {
@@ -99,8 +100,6 @@ class MainActivity : BaseActivity<ActivityHomeBinding, UserInfoViewModel>({ Acti
                         }
                     }
                 }
-            }
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     popupViewModel.serverError.collect {
                         it?.let {
@@ -108,18 +107,8 @@ class MainActivity : BaseActivity<ActivityHomeBinding, UserInfoViewModel>({ Acti
                         }
                     }
                 }
-                launch {
-                    GlobalEvent.logoutEvent.collect {
-                        if (it) {
-                            startActivity(Intent(this@MainActivity, SplashActivity::class.java))
-                            finish()
-                            GlobalEvent.resetLogoutEvent()
-                        }
-                    }
-                }
             }
         }
-
     }
 
     private fun initNavView() {

--- a/app/src/main/java/com/zion830/threedollars/ui/login/ui/LoginActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/login/ui/LoginActivity.kt
@@ -1,5 +1,6 @@
 package com.zion830.threedollars.ui.login.ui
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
@@ -55,6 +56,9 @@ class LoginActivity : BaseActivity<ActivityLoginBinding, LoginViewModel>({ Activ
 
     override fun initView() {
         setDarkSystemBars()
+        if (intent.getBooleanExtra(SESSION_EXPIRED, false)) {
+            showToast(CommonR.string.session_expired)
+        }
         collectFlows()
         binding.btnLoginKakao.onSingleClick {
             viewModel.sendClickKakaoLogin()
@@ -231,6 +235,19 @@ class LoginActivity : BaseActivity<ActivityLoginBinding, LoginViewModel>({ Activ
             UserApiClient.instance.loginWithKakaoTalk(this, callback = loginResCallback)
         } else {
             UserApiClient.instance.loginWithKakaoAccount(this, callback = loginResCallback)
+        }
+    }
+
+    companion object {
+        private const val SESSION_EXPIRED = "sessionExpired"
+
+        /**
+         * 세션 만료로 로그인이 필요할 때 사용하는 Intent.
+         * 기존 화면 스택을 모두 정리하고 로그인 화면을 새 태스크의 시작점으로 만든다.
+         */
+        fun getSessionExpiredIntent(context: Context) = Intent(context, LoginActivity::class.java).apply {
+            putExtra(SESSION_EXPIRED, true)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         }
     }
 }

--- a/app/src/main/java/com/zion830/threedollars/ui/login/ui/LoginActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/login/ui/LoginActivity.kt
@@ -241,10 +241,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding, LoginViewModel>({ Activ
     companion object {
         private const val SESSION_EXPIRED = "sessionExpired"
 
-        /**
-         * 세션 만료로 로그인이 필요할 때 사용하는 Intent.
-         * 기존 화면 스택을 모두 정리하고 로그인 화면을 새 태스크의 시작점으로 만든다.
-         */
+        /** 세션 만료로 로그인이 필요할 때 사용하는 Intent. 기존 화면 스택을 모두 정리한다. */
         fun getSessionExpiredIntent(context: Context) = Intent(context, LoginActivity::class.java).apply {
             putExtra(SESSION_EXPIRED, true)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -607,4 +607,5 @@
     <string name="str_vote_empty_title">내가 올린 투표가 없어요</string>
     <string name="str_vote_empty_message">가게 상세에서 추가해 보세요</string>
     <string name="str_team_title">팀원소개</string>
+    <string name="session_expired">세션이 만료되었습니다.\n다시 로그인해주세요.</string>
 </resources>


### PR DESCRIPTION
## 원인

401 감지 자체는 되고 있었지만, **이벤트를 구독하는 코드가 실행되지 않는 dead code**였습니다.

**문제 코드:** `MainActivity.kt` — `initFlow()` (기존 92-123행)

```kotlin
lifecycleScope.launch {
    repeatOnLifecycle(Lifecycle.State.CREATED) {   // ← DESTROYED까지 suspend, 절대 리턴하지 않음
        launch { popupViewModel.popups.collect { ... } }
    }
    repeatOnLifecycle(Lifecycle.State.STARTED) {   // ← 도달 불가
        launch { popupViewModel.serverError.collect { ... } }
        launch {
            GlobalEvent.logoutEvent.collect { ... }  // ← 구독 자체가 등록되지 않음
        }
    }
}
```

`repeatOnLifecycle`은 lifecycle이 DESTROYED가 될 때까지 suspend하므로 같은 코루틴 안의 두 번째 블록은 영원히 실행되지 않습니다. 결과적으로 `NetworkModule.kt`의 `Authenticator`가 401에서 `GlobalEvent.triggerLogout()`을 호출해도 **아무도 구독하고 있지 않아** 로그인 화면 이동이 일어나지 않고, 화면별 ViewModel이 띄우는 서버 메시지 토스트("세션이 만료되었습니다")만 남았습니다. 이것이 리포트된 증상 그대로입니다.

같은 이유로 `popupViewModel.serverError` 토스트도 동작하지 않고 있었습니다.

추가로 확인된 문제 2가지:

1. **딥링크 목적지가 `MainActivity`가 아니면 구독처가 아예 없음.** `GlobalEvent` 구독은 `MainActivity` 한 곳뿐인데, 딥링크는 `PollDetailActivity`(`/pollDetail`), `FavoriteViewerActivity`(`/bookmark`), `StoreDetailActivity`(`/store`, `/visit`) 등으로도 진입합니다.
2. **세션이 정리되지 않음.** `GlobalApplication.isLoggedIn`은 로컬에 저장된 로그인 "타입" 문자열 존재 여부만 보므로, 세션이 만료돼도 계속 `true`입니다. 만료된 액세스 토큰도 헤더에 계속 붙습니다.

## 재현 경로

1. 로그아웃하거나 세션이 만료된 상태
2. 푸시 알림 또는 다이나믹 링크(`dollars://community`)로 앱 진입
3. 실제 결과: "세션 만료" 토스트만 뜨고 커뮤니티 탭에 그대로 머무름
4. 기대 결과: 로그인 필요 안내 후 로그인 화면으로 이동

## 수정 방향

iOS는 `BaseViewController.showErrorAlert()`에서 `UA000`을 받으면 "세션이 만료되었습니다. 다시 로그인해주세요." 알럿을 띄우고, 확인 시 `AppModuleInterfaceImpl.onClearSession()` → `Preference.shared.clear()` + `SceneDelegate.goToSignIn()`으로 **로컬 세션을 지우고 루트를 로그인 화면으로 교체**합니다. 모든 화면이 상속받는 구조라 진입 경로와 무관하게 동작합니다.

Android도 동일한 동작이 되도록, 화면 단위가 아니라 **프로세스 단위**로 세션 만료를 처리하도록 옮겼습니다. Android에서는 `BaseActivity`가 `core:common`에 있어 `LoginActivity`를 참조할 수 없고, 딥링크 목적지가 `BaseActivity`를 상속하지 않는 경우도 있어 `GlobalApplication`에 두는 편이 누락이 없습니다.

**수정 내용:**
- `MainActivity.kt`: 두 번째 `repeatOnLifecycle` 블록을 첫 번째 안으로 합쳐 dead code 제거 (`serverError` 토스트도 함께 복구)
- `GlobalApplication.kt`: `GlobalEvent.logoutEvent`를 프로세스 스코프에서 관찰 → 로컬 로그인 정보 정리 후 로그인 화면으로 이동
- `LoginActivity.kt`: `getSessionExpiredIntent()` 추가 (`FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK`로 스택 정리) + 진입 시 안내 문구 노출
- `strings.xml`: `session_expired` 문구 추가

세션 만료 중 여러 요청이 동시에 401을 받아도 로그인 화면으로 중복 이동하지 않도록, `logoutEvent`는 `StateFlow`의 중복 값 제거 특성을 그대로 이용하고 **로그인에 성공해 `MainActivity`에 진입할 때 초기화**합니다.

## 검증

- ✅ `./gradlew :app:assembleDebug` BUILD SUCCESSFUL
- ✅ **에뮬레이터 Before/After 검증 PASS** (Medium_Phone_API_36.1 / Android 16, adb 기반 UI 자동화)
  - 시나리오: `adb shell pm clear`로 로그아웃 상태를 만든 뒤 `adb shell am start -a android.intent.action.VIEW -d "dollars://community"` 로 딥링크 진입
  - 두 실행 모두 동일하게 401이 발생한 것을 logcat으로 확인
    ```
    <-- 401 https://dev.threedollars.co.kr/api/v2/user/me
    {"ok":false,"resultCode":"UA000","error":"unauthorized","message":"세션이 만료되었습니다 다시 로그인 해주세요"}
    ```
  - **Before (develop)**: 401이 발생했는데도 `topResumedActivity`가 `MainActivity` — 커뮤니티 탭에 그대로 머무름 → 티켓 버그 재현 확인
  - **After (본 브랜치)**: 동일한 401에서 `topResumedActivity`가 `LoginActivity`로 전환되고 세션 만료 안내 노출
  - LoginActivity가 받은 Intent가 `flg=0x10008000`(`NEW_TASK|CLEAR_TASK`) + `has extras` 로 확인되어, 본 PR의 `getSessionExpiredIntent()` 경로를 탄 것이 확정됨

### 에뮬레이터 검증 스크린샷

| Before (develop) — 커뮤니티 탭에 머무름 | After (본 브랜치) — 안내 후 로그인 화면 |
|:---:|:---:|
| <img src="https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/download/verification-assets/TH-821-before.png" width="320"> | <img src="https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/download/verification-assets/TH-821-after.png" width="320"> |

> After 스크린샷에 보이는 토스트 문구는 서버가 내려준 `UA000` 메시지입니다. 본 PR이 추가한 `session_expired` 문구와 함께 큐잉되어 노출되며, 캡처 시점에 마지막으로 표시된 쪽이 서버 메시지입니다.

추가로 수동 확인이 필요한 항목:
1. 로그인 상태에서 서버 토큰이 실제로 만료된 경우에도 동일하게 동작하는지 (에뮬레이터에서는 `run-as` 쓰기가 SELinux로 막혀 토큰만 만료시키는 검증은 수행하지 못했고, 티켓이 명시한 "로그아웃 상태"로 재현했습니다)
2. 딥링크 목적지가 `MainActivity`가 아닌 경우(`/pollDetail`, `/bookmark`)도 동일 동작
3. 다시 로그인 후 정상 진입되고, 이후 세션 만료가 다시 감지되는지

## 영향 범위

- 401(세션 만료)이 발생하는 **모든 화면**의 동작이 바뀝니다. 기존에는 토스트만 떴고, 이제는 로그인 화면으로 이동합니다.
- **리스크:** 중간 — 전역 동작 변경입니다. 다만 기존 코드의 *의도된* 동작(`MainActivity`에 이미 존재했으나 실행되지 않던 로직)을 실제로 동작하게 만든 것이라 방향 자체는 기존 설계와 같습니다.
- ⚠️ **TH-1072(#297)와 함께 머지해 주세요.** 현재 `SplashActivity`는 비로그인 상태에서도 푸시 토큰 등록(`PUT /api/v2/device`)을 호출해 401을 유발합니다. 본 PR만 머지하면 **비로그인 유저가 앱 실행 시 "세션이 만료되었습니다" 안내를 받는** 문제가 생깁니다. #297이 그 호출을 로그인 상태에서만 하도록 막습니다.
- 이번 범위에서 다루지 않은 것: iOS의 딥링크 예약·재생(`DeepLinkHandler.reservedDeepLink` → 로그인 후 원래 목적지로 복귀) 기능은 Android에 없습니다. 로그인 후 원래 딥링크로 돌아가지 않고 홈으로 진입합니다. 별도 티켓 권장합니다.

## 관련 이슈

- Jira: TH-821