### PR TITLE
TH-1132 : 앱 실행 시 현재 위치 대신 기본 위치(중구)로 이동하던 문제 수정

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/MainActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/MainActivity.kt
@@ -33,7 +33,7 @@ import com.zion830.threedollars.databinding.ActivityHomeBinding
 import com.zion830.threedollars.ui.popup.PopupViewModel
 import com.zion830.threedollars.ui.splash.ui.SplashActivity
 import com.zion830.threedollars.ui.webview.WebActivity
-import com.zion830.threedollars.utils.isGpsAvailable
+import com.zion830.threedollars.utils.isLocationServiceEnabled
 import com.zion830.threedollars.utils.isLocationAvailable
 import com.zion830.threedollars.utils.showToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -59,7 +59,7 @@ class MainActivity : BaseActivity<ActivityHomeBinding, UserInfoViewModel>({ Acti
         setDarkSystemBars()
         fusedLocationProviderClient =
             LocationServices.getFusedLocationProviderClient(this)
-        if (isLocationAvailable() && isGpsAvailable()) {
+        if (isLocationAvailable() && isLocationServiceEnabled()) {
             val locationResult = fusedLocationProviderClient.lastLocation
             locationResult.addOnSuccessListener {
                 if (it != null) {

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -770,14 +770,20 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
         }
     }
     
+    /**
+     * 현재 위치를 확인하지 못했을 때 사용할 위치로 지도를 이동한다.
+     *
+     * 마지막으로 확인된 위치가 있으면 그 위치를, 없으면 기본 위치(서울 중심)를 쓴다.
+     */
     private fun useDefaultLocation() {
-        naverMapFragment.moveCamera(NaverMapUtils.DEFAULT_LOCATION)
+        val fallbackLocation = naverMapFragment.getCachedUserLocation() ?: NaverMapUtils.DEFAULT_LOCATION
+        naverMapFragment.moveCamera(fallbackLocation)
 
         viewModel.fetchAroundStores(
-            mapPosition = NaverMapUtils.DEFAULT_LOCATION,
-            userLocation = NaverMapUtils.DEFAULT_LOCATION,
+            mapPosition = fallbackLocation,
+            userLocation = fallbackLocation,
         )
-        viewModel.getAdvertisement(latLng = NaverMapUtils.DEFAULT_LOCATION)
+        viewModel.getAdvertisement(latLng = fallbackLocation)
     }
     
     private fun showLocationPermissionDialog() {

--- a/app/src/main/java/com/zion830/threedollars/ui/map/ui/NaverMapFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/map/ui/NaverMapFragment.kt
@@ -58,7 +58,7 @@ import com.zion830.threedollars.utils.NaverMapUtils.DEFAULT_DISTANCE_M
 import com.zion830.threedollars.utils.NaverMapUtils.calculateDistance
 import com.zion830.threedollars.utils.OnMapTouchListener
 import com.zion830.threedollars.utils.TouchableWrapper
-import com.zion830.threedollars.utils.isGpsAvailable
+import com.zion830.threedollars.utils.isLocationServiceEnabled
 import com.zion830.threedollars.utils.isLocationAvailable
 import com.zion830.threedollars.utils.requestPermissionIfNeeds
 import com.zion830.threedollars.utils.urlToBitmap
@@ -84,6 +84,15 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
     var listener: OnMapTouchListener? = null
 
     private var isShowOverlay = true
+
+    /**
+     * 지도가 최초 카메라 위치로 이동했는지 여부.
+     *
+     * 지도 SDK는 준비 직후 자체 기본 위치(서울시청)에 카메라를 두고 변경 이벤트를 발생시킨다.
+     * 이 값을 저장된 지도 위치로 남기면 다음 실행에서 현재 위치를 요청하지 않고 그 위치로 이동해버리므로,
+     * 실제 위치가 정해지기 전까지는 [mapPosition]을 갱신하지 않는다.
+     */
+    private var isInitialCameraPlaced = false
 
     var onAdMarkerClicked: ((Int) -> Unit)? = null
 
@@ -144,7 +153,9 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
             map.locationOverlay.bearing = 0f
         }
         map.addOnCameraChangeListener { _, _ ->
-            mapPosition.value = map.cameraPosition.target
+            if (isInitialCameraPlaced) {
+                mapPosition.value = map.cameraPosition.target
+            }
             map.contentBounds.let {
                 val northWest = it.northWest
                 val southEast = it.southEast
@@ -462,7 +473,7 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
 
     @SuppressLint("MissingPermission")
     private fun requestCurrentLocation(onLocationLoaded: (LatLng?) -> Unit) {
-        if (!isLocationAvailable() || !isGpsAvailable()) {
+        if (!isLocationAvailable() || !isLocationServiceEnabled()) {
             onLocationLoaded(null)
             return
         }
@@ -517,6 +528,7 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
             return
         }
 
+        isInitialCameraPlaced = true
         val cameraUpdate = CameraUpdate.scrollTo(position)
         naverMap?.moveCamera(cameraUpdate)
     }
@@ -526,6 +538,7 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
             return
         }
 
+        isInitialCameraPlaced = true
         val cameraUpdate = CameraUpdate.scrollTo(position).animate(CameraAnimation.Easing)
         naverMap?.moveCamera(cameraUpdate)
     }

--- a/app/src/main/java/com/zion830/threedollars/ui/map/ui/NaverMapFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/map/ui/NaverMapFragment.kt
@@ -43,6 +43,7 @@ import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
 import com.threedollar.common.serverdriven.ext.displayText
+import com.threedollar.common.utils.SharedPrefUtils
 import com.threedollar.domain.home.data.store.ContentModel
 import com.threedollar.domain.home.data.store.MarkerModel
 import com.threedollar.common.serverdriven.model.HomeListCardModel
@@ -66,6 +67,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
 @AndroidEntryPoint
 open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyCallback {
@@ -76,6 +78,9 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
     var mapViewPortDistance: MutableLiveData<Double> = MutableLiveData(DEFAULT_DISTANCE_M)
 
     protected lateinit var binding: FragmentNaverMapBinding
+
+    @Inject
+    lateinit var sharedPrefUtils: SharedPrefUtils
 
     private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
 
@@ -481,7 +486,7 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
         fusedLocationProviderClient.lastLocation
             .addOnSuccessListener { location ->
                 if (location != null) {
-                    onLocationLoaded(location.toLatLng())
+                    onLocationLoaded(location.toLatLng().also { cacheUserLocation(it) })
                 } else {
                     requestFreshCurrentLocation(onLocationLoaded)
                 }
@@ -491,6 +496,18 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
                 requestFreshCurrentLocation(onLocationLoaded)
             }
     }
+
+    private fun cacheUserLocation(position: LatLng) {
+        sharedPrefUtils.saveUserLastLocation(latitude = position.latitude, longitude = position.longitude)
+    }
+
+    /**
+     * 마지막으로 확인된 사용자 위치. 저장된 값이 없으면 null.
+     *
+     * 위치 획득에 실패했을 때 서울 중심 좌표로 떨어지기 전에 우선 사용한다.
+     */
+    fun getCachedUserLocation(): LatLng? =
+        sharedPrefUtils.getUserLastLocation()?.let { (latitude, longitude) -> LatLng(latitude, longitude) }
 
     @SuppressLint("MissingPermission")
     private fun requestFreshCurrentLocation(onLocationLoaded: (LatLng?) -> Unit) {
@@ -502,7 +519,7 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
         fusedLocationProviderClient
             .getCurrentLocation(request, cancellationTokenSource.token)
             .addOnSuccessListener { location ->
-                onLocationLoaded(location?.toLatLng())
+                onLocationLoaded(location?.toLatLng()?.also { cacheUserLocation(it) })
             }
             .addOnFailureListener { exception ->
                 Log.e(this::class.java.name, exception.message ?: "")
@@ -516,7 +533,13 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
     private fun Location.toLatLng(): LatLng = LatLng(latitude, longitude)
 
     private companion object {
-        const val CURRENT_LOCATION_TIMEOUT_MILLIS = 5_000L
+        /**
+         * 위치 수신 대기 시간.
+         *
+         * 실내나 측위가 느린 환경에서 5초는 첫 fix를 받기에 부족해 기본 위치로 떨어지는 경우가 잦았다.
+         * iOS는 타임아웃 없이 첫 fix까지 기다린다.
+         */
+        const val CURRENT_LOCATION_TIMEOUT_MILLIS = 10_000L
     }
 
     fun setIsShowOverlay(isVisible: Boolean) {

--- a/app/src/main/java/com/zion830/threedollars/ui/map/ui/NearStoreNaverMapFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/map/ui/NearStoreNaverMapFragment.kt
@@ -48,12 +48,10 @@ class NearStoreNaverMapFragment(
         }
         if (isFirstLoad) {
             val savedPosition = viewModel.getSavedMapPosition()
-            if (savedPosition != null) {
-                moveCamera(savedPosition)
-            } else {
-                if (isLocationAvailable()) {
-                    moveToCurrentLocation()
-                }
+            when {
+                savedPosition != null -> moveCamera(savedPosition)
+                isLocationAvailable() -> moveToCurrentLocation()
+                else -> moveCamera(NaverMapUtils.DEFAULT_LOCATION)
             }
             isFirstLoad = false
         }

--- a/app/src/main/java/com/zion830/threedollars/ui/map/ui/NearStoreNaverMapFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/map/ui/NearStoreNaverMapFragment.kt
@@ -51,7 +51,7 @@ class NearStoreNaverMapFragment(
             when {
                 savedPosition != null -> moveCamera(savedPosition)
                 isLocationAvailable() -> moveToCurrentLocation()
-                else -> moveCamera(NaverMapUtils.DEFAULT_LOCATION)
+                else -> moveCamera(getCachedUserLocation() ?: NaverMapUtils.DEFAULT_LOCATION)
             }
             isFirstLoad = false
         }

--- a/app/src/main/java/com/zion830/threedollars/ui/splash/ui/SplashActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/splash/ui/SplashActivity.kt
@@ -21,6 +21,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.naver.maps.geometry.LatLng
 import com.threedollar.common.base.BaseActivity
 import com.threedollar.common.ext.loadImage
+import com.threedollar.common.utils.SharedPrefUtils
 import com.threedollar.network.request.PushInformationRequest
 import com.zion830.threedollars.BuildConfig
 import com.zion830.threedollars.DynamicLinkActivity
@@ -39,11 +40,15 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
+import javax.inject.Inject
 import com.threedollar.common.R as CommonR
 
 @AndroidEntryPoint
 class SplashActivity :
     BaseActivity<ActivitySplashBinding, SplashViewModel>({ ActivitySplashBinding.inflate(it) }) {
+
+    @Inject
+    lateinit var sharedPrefUtils: SharedPrefUtils
 
     override val viewModel: SplashViewModel by viewModels()
     private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
@@ -118,6 +123,8 @@ class SplashActivity :
             val locationResult = fusedLocationProviderClient.lastLocation
             locationResult.addOnSuccessListener {
                 if (it != null) {
+                    // 홈 진입 시 위치 획득에 실패해도 재사용할 수 있도록 저장해둔다.
+                    sharedPrefUtils.saveUserLastLocation(latitude = it.latitude, longitude = it.longitude)
                     viewModel.getStoreMarkerAdvertisements(
                         latLng = LatLng(it.latitude, it.longitude)
                     )

--- a/app/src/main/java/com/zion830/threedollars/ui/splash/ui/SplashActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/splash/ui/SplashActivity.kt
@@ -30,7 +30,7 @@ import com.zion830.threedollars.ui.login.ui.LoginActivity
 import com.zion830.threedollars.ui.splash.viewModel.SplashViewModel
 import com.zion830.threedollars.ui.storeDetail.boss.ui.BossStoreDetailActivity
 import com.zion830.threedollars.ui.storeDetail.user.ui.StoreDetailActivity
-import com.zion830.threedollars.utils.isGpsAvailable
+import com.zion830.threedollars.utils.isLocationServiceEnabled
 import com.zion830.threedollars.utils.isLocationAvailable
 import com.zion830.threedollars.utils.showToast
 import com.zion830.threedollars.ui.dialog.VersionUpdateDialog
@@ -114,7 +114,7 @@ class SplashActivity :
     private fun initAdvertisements() {
         fusedLocationProviderClient =
             LocationServices.getFusedLocationProviderClient(this)
-        if (isLocationAvailable() && isGpsAvailable()) {
+        if (isLocationAvailable() && isLocationServiceEnabled()) {
             val locationResult = fusedLocationProviderClient.lastLocation
             locationResult.addOnSuccessListener {
                 if (it != null) {

--- a/app/src/main/java/com/zion830/threedollars/ui/storeDetail/boss/ui/BossStoreDetailActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/storeDetail/boss/ui/BossStoreDetailActivity.kt
@@ -70,7 +70,7 @@ import com.zion830.threedollars.utils.OnMapTouchListener
 import com.zion830.threedollars.utils.ShareFormat
 import com.zion830.threedollars.utils.SizeUtils.dpToPx
 import com.zion830.threedollars.utils.SpaceItemDecoration
-import com.zion830.threedollars.utils.isGpsAvailable
+import com.zion830.threedollars.utils.isLocationServiceEnabled
 import com.zion830.threedollars.utils.isLocationAvailable
 import com.zion830.threedollars.utils.navigateToMainActivityOnCloseIfNeeded
 import com.zion830.threedollars.utils.shareWithKakao
@@ -276,7 +276,7 @@ class BossStoreDetailActivity :
         fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
         storeId = intent.getStringExtra(STORE_ID).toString()
         try {
-            if (isLocationAvailable() && isGpsAvailable()) {
+            if (isLocationAvailable() && isLocationServiceEnabled()) {
                 fusedLocationProviderClient.lastLocation.addOnSuccessListener { location ->
                     if (location != null) {
                         viewModel.getFoodTruckStoreDetail(

--- a/app/src/main/java/com/zion830/threedollars/ui/storeDetail/user/ui/StoreCertificationActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/storeDetail/user/ui/StoreCertificationActivity.kt
@@ -14,7 +14,7 @@ import com.zion830.threedollars.R
 import com.zion830.threedollars.databinding.ActivityStoreCertificationBinding
 import com.zion830.threedollars.ui.storeDetail.user.viewModel.StoreCertificationViewModel
 import com.zion830.threedollars.utils.NaverMapUtils
-import com.zion830.threedollars.utils.isGpsAvailable
+import com.zion830.threedollars.utils.isLocationServiceEnabled
 import com.zion830.threedollars.utils.isLocationAvailable
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -40,7 +40,7 @@ class StoreCertificationActivity :
 
     @SuppressLint("MissingPermission")
     private fun openCertification(args: StoreCertificationArgs) {
-        if (!isLocationAvailable() || !isGpsAvailable()) {
+        if (!isLocationAvailable() || !isLocationServiceEnabled()) {
             showCertificationFragment(args = args, currentLocation = null)
             return
         }

--- a/app/src/main/java/com/zion830/threedollars/ui/storeDetail/user/ui/StoreDetailActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/storeDetail/user/ui/StoreDetailActivity.kt
@@ -88,7 +88,7 @@ import com.zion830.threedollars.utils.NaverMapUtils
 import com.zion830.threedollars.utils.OnMapTouchListener
 import com.zion830.threedollars.utils.ShareFormat
 import com.zion830.threedollars.utils.goToPermissionSetting
-import com.zion830.threedollars.utils.isGpsAvailable
+import com.zion830.threedollars.utils.isLocationServiceEnabled
 import com.zion830.threedollars.utils.isLocationAvailable
 import com.zion830.threedollars.utils.navigateToMainActivityOnCloseIfNeeded
 import com.zion830.threedollars.utils.shareWithKakao
@@ -894,7 +894,7 @@ class StoreDetailActivity : BaseActivity<ActivityStoreInfoBinding, StoreDetailVi
 
     private fun refreshStoreInfo() {
         try {
-            if (isLocationAvailable() && isGpsAvailable()) {
+            if (isLocationAvailable() && isLocationServiceEnabled()) {
                 val locationResult = fusedLocationProviderClient.lastLocation
                 locationResult.addOnSuccessListener {
                     if (it != null) {

--- a/app/src/main/java/com/zion830/threedollars/utils/SystemUtils.kt
+++ b/app/src/main/java/com/zion830/threedollars/utils/SystemUtils.kt
@@ -24,6 +24,7 @@ import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.location.LocationManagerCompat
 import androidx.databinding.DataBindingUtil
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
@@ -114,10 +115,16 @@ fun isLocationAvailable(): Boolean =
         ACCESS_FINE_LOCATION
     ) == PackageManager.PERMISSION_GRANTED
 
-fun isGpsAvailable(): Boolean {
+/**
+ * 기기의 위치 서비스가 켜져 있는지 확인한다.
+ *
+ * GPS 프로바이더만 확인하면 실내이거나 위치 정확도가 "배터리 절약"으로 설정된 경우
+ * 네트워크 측위로는 위치를 받을 수 있는데도 실패로 처리된다.
+ */
+fun isLocationServiceEnabled(): Boolean {
     val locationManager =
         GlobalApplication.getContext().getSystemService(LOCATION_SERVICE) as LocationManager
-    return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
+    return LocationManagerCompat.isLocationEnabled(locationManager)
 }
 
 fun getCurrentLocationName(location: LatLng?): String? {

--- a/core/common/src/main/java/com/threedollar/common/utils/SharedPrefUtils.kt
+++ b/core/common/src/main/java/com/threedollar/common/utils/SharedPrefUtils.kt
@@ -128,8 +128,32 @@ class SharedPrefUtils @Inject constructor(@ApplicationContext private val contex
         saveUserId(-1)
     }
 
+    /**
+     * 마지막으로 확인된 사용자 위치를 저장한다.
+     *
+     * 위치 획득에 실패했을 때 서울 중심 좌표로 떨어지는 대신 직전에 확인된 위치를 쓰기 위한 캐시다.
+     */
+    fun saveUserLastLocation(latitude: Double, longitude: Double) = sharedPreferences.edit {
+        putLong(USER_LAST_LATITUDE, latitude.toRawBits())
+        putLong(USER_LAST_LONGITUDE, longitude.toRawBits())
+        commit()
+    }
+
+    /** 저장된 사용자 위치를 `위도 to 경도`로 반환한다. 저장된 값이 없으면 null. */
+    fun getUserLastLocation(): Pair<Double, Double>? {
+        if (!sharedPreferences.contains(USER_LAST_LATITUDE) || !sharedPreferences.contains(USER_LAST_LONGITUDE)) {
+            return null
+        }
+
+        val latitude = Double.fromBits(sharedPreferences.getLong(USER_LAST_LATITUDE, 0L))
+        val longitude = Double.fromBits(sharedPreferences.getLong(USER_LAST_LONGITUDE, 0L))
+        return latitude to longitude
+    }
+
     companion object {
         private const val PREFERENCE_FILE_KEY = "preference_file_key"
+        private const val USER_LAST_LATITUDE = "user_last_latitude"
+        private const val USER_LAST_LONGITUDE = "user_last_longitude"
         private const val KAKAO_ACCESS_TOKEN = "kakao_access_token"
         private const val KAKAO_REFRESH_TOKEN = "kakao_refresh_token"
         private const val USER_ID_KEY = "user_id_key"


### PR DESCRIPTION
## 원인

"중구"는 앱의 폴백 좌표인 `NaverMapUtils.DEFAULT_LOCATION = LatLng(37.56, 126.97)`(서울시청 일대)입니다. 이 폴백으로 빠지는 경로가 아래 세 군데였습니다.

### 1. 위치를 못 받으면 곧바로 기본 위치로 (에뮬레이터에서 재현된 경로)

`HomeFragment.useDefaultLocation()`은 직전에 확인된 위치가 있든 없든 무조건 `DEFAULT_LOCATION`을 씁니다. 그래서 **바로 전까지 강남에 있었어도** 한 번 위치 획득에 실패하면 중구로 점프합니다.

여기에 Android에만 있는 하드 타임아웃이 겹칩니다.

```kotlin
// NaverMapFragment.kt
.setDurationMillis(CURRENT_LOCATION_TIMEOUT_MILLIS)  // 5_000L
```

`lastLocation`이 null이면 `getCurrentLocation`으로 넘어가는데, 실내나 측위가 느린 환경에서 5초는 첫 fix를 받기에 부족합니다. iOS는 타임아웃 없이 `startUpdatingLocation()`으로 첫 fix까지 기다리고, 받은 위치를 `Preference.userCurrentLocation`에 **영구 캐시**해 다음 실행에 재사용합니다. Android에는 이 캐시가 아예 없어서 매 실행마다 처음부터 시작합니다.

`SplashActivity`가 이미 `lastLocation`을 받아오고 있는데도 광고 조회에만 쓰고 버리는 것도 같은 맥락입니다.

### 2. 위치 서비스 판정이 GPS 프로바이더만 확인

```kotlin
fun isGpsAvailable(): Boolean {
    val locationManager = ... as LocationManager
    return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
}
```

`NaverMapFragment.requestCurrentLocation()`에서 하드 게이트로 쓰이는데, `GPS_PROVIDER`만 보기 때문에 **위치 권한이 있어도** 실내이거나 기기 위치 정확도가 "배터리 절약"(네트워크 측위)이면 즉시 `null`이 되어 폴백합니다. 실제로는 `NETWORK_PROVIDER`/Fused로 위치를 받을 수 있는 상황입니다.

iOS는 프로바이더별이 아니라 위치 서비스 전체 스위치를 봅니다 — `LocationManager.swift`의 `CLLocationManager.locationServicesEnabled()`.

### 3. 지도 SDK 기본 위치가 "저장된 지도 위치"로 오염됨

```kotlin
// NaverMapFragment.kt - initMapUiSetting()
map.addOnCameraChangeListener { _, _ ->
    mapPosition.value = map.cameraPosition.target   // ← 이유(reason)를 가리지 않음
```

지도 SDK는 준비 직후 자체 기본 위치(서울시청 `37.5666, 126.9784`)에 카메라를 두고 변경 이벤트를 발생시킵니다. 이 값이 `HomeFragment` → `HomeViewModel.updateMapPosition()` → `savedStateHandle[KEY_MAP_POSITION]`으로 **저장**됩니다.

이후 지도 프래그먼트가 다시 만들어지면 `NearStoreNaverMapFragment.onMapReady`에서 저장값이 존재하므로 **현재 위치를 요청조차 하지 않고** 중구로 이동합니다. `HomeViewModel`은 `activityViewModels()` 스코프이고 `savedStateHandle`은 프로세스 재생성 시에도 복원되므로, 탭 전환·상세화면 복귀·프로세스 재생성 이후 진입에서 재현됩니다.

## 재현 경로

1. 위치 권한을 허용한 상태로 앱을 실행해 현재 위치(예: 강남)가 정상 표시되는 것을 확인
2. 실내로 이동하거나 위치 정확도를 "배터리 절약"으로 변경 (또는 위치 서비스 off)
3. 앱 재실행
4. 실제 결과: 직전 위치와 무관하게 **중구(서울시청)** 로 이동, 주변 가게도 중구 기준으로 조회
5. 기대 결과: 현재 위치, 최소한 직전에 확인된 위치

## 수정 방향

iOS의 `Preference.userCurrentLocation` 캐시 모델을 그대로 가져왔습니다. 위치를 받을 때마다 캐시에 저장하고, 획득에 실패하면 기본 위치로 떨어지기 전에 캐시를 먼저 씁니다. 위치 서비스 판정도 iOS와 같은 기준으로 맞췄습니다.

**수정 내용:**

- `SharedPrefUtils.kt`: `saveUserLastLocation()` / `getUserLastLocation()` 추가 (위경도를 `Double` 비트로 저장해 정밀도 손실 없음)
- `NaverMapFragment.kt`: 위치 획득에 성공할 때마다 캐시 갱신, `getCachedUserLocation()` 노출
- `NaverMapFragment.kt`: 위치 수신 타임아웃 5초 → 10초
- `NaverMapFragment.kt`: `isGpsAvailable()` → `isLocationServiceEnabled()`로 이름을 바꾸고 `LocationManagerCompat.isLocationEnabled()` 사용. 호출처 5곳(`SplashActivity`, `MainActivity`, `StoreDetailActivity`, `StoreCertificationActivity`, `BossStoreDetailActivity`)도 함께 반영
- `HomeFragment.kt`: `useDefaultLocation()`이 캐시된 위치를 우선 사용
- `NearStoreNaverMapFragment.kt`: 저장 위치도 권한도 없을 때 캐시 → 기본 위치 순으로 폴백. 기존에는 어느 분기에도 걸리지 않아 카메라 위치가 확정되지 않는 경로가 있었음
- `NaverMapFragment.kt`: `isInitialCameraPlaced` 플래그를 추가해, 실제 위치가 정해지기 전(지도 SDK 기본 위치)의 카메라 변경은 `mapPosition`으로 내보내지 않도록 수정
- `SplashActivity.kt`: 스플래시에서 이미 조회한 `lastLocation`을 캐시에 저장해 홈 진입 시 재사용

`mapPosition`을 관찰하는 곳은 `HomeFragment` 한 곳이고, 홈의 위치 처리 흐름은 모든 종료 지점에서 `moveCamera()`를 호출합니다(`loadHomeWithCurrentLocation` 성공/실패, `useDefaultLocation`, 권한 거부 콜백). 따라서 플래그 때문에 `mapPosition`이 영영 갱신되지 않는 경로는 없습니다.

## 검증

- ✅ `./gradlew :app:assembleDebug` BUILD SUCCESSFUL
- ✅ **에뮬레이터 Before/After 검증 PASS** (Medium_Phone_API_36.1 / Android 16, adb 기반 UI 자동화)
  - 시나리오: 위치 서비스 ON + 모의 위치 강남역(`37.497941, 127.027616`)으로 실행해 현재 위치 표시 확인 → `adb shell cmd location set-location-enabled false`로 위치 서비스 차단 → 앱 재실행
  - **Before (develop)**: 직전까지 강남을 정상 표시했음에도 재실행 시 `서울특별시 중구 의주로2가 16-8` → 티켓 버그 재현 확인
  - **After (본 브랜치)**: 동일 조건에서 `서울특별시 역삼동 강남` 유지 → 마지막 확인 위치로 폴백
  - 두 실행 모두 동일 에뮬레이터·동일 권한·동일 모의 위치 상태에서 APK만 교체해 비교

### 에뮬레이터 검증 스크린샷

| Before (develop) — 위치 서비스 차단 시 중구로 이동 | After (본 브랜치) — 마지막 확인 위치(강남) 유지 |
|:---:|:---:|
| <img src="https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/download/verification-assets/TH-1132-before.png" width="320"> | <img src="https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/download/verification-assets/TH-1132-after.png" width="320"> |

추가로 수동 확인이 필요한 항목:
1. 위치 정확도를 "배터리 절약"으로 두고 실행 → 현재 위치로 이동하는지 (GPS-only 판정 수정분)
2. 홈에서 지도를 이동한 뒤 다른 탭 갔다가 돌아왔을 때 이동해둔 위치가 유지되는지 (저장 위치 복원 기능 회귀 확인)
3. 앱 최초 설치 직후(캐시 없음) + 위치 획득 실패 → 기존과 동일하게 기본 위치로 동작하는지

## 영향 범위

- 홈 지도의 초기 카메라 위치, 그리고 위치 게이트를 쓰는 화면들(스플래시 광고 조회, 가게 상세 거리 표시, 방문 인증)의 위치 획득 성공률이 올라갑니다.
- 위치 캐시는 `preference_file_key`에 위경도 2개 키로 저장됩니다. 로그아웃 시 지워지는 사용자 정보와는 별개 값입니다.
- **리스크:** 낮음~중간 — 위치 판정이 느슨해지는 방향(GPS만 → 전체 위치 서비스)이라 기존에 성공하던 케이스가 실패하지는 않습니다. 타임아웃을 5초 → 10초로 늘렸으므로, 위치를 끝내 못 받는 환경에서는 기본 위치로 떨어지기까지 최대 5초 더 걸릴 수 있습니다. 다만 캐시가 있으면 그 사이에도 직전 위치가 쓰입니다.
- 이번 범위에서 다루지 않은 것: iOS는 위치 획득 실패 시 사용자에게 알럿을 띄우지만(`HomeViewModel.swift`), Android는 조용히 폴백합니다.

## 관련 이슈

- Jira: TH-1132