### PR TITLE
TH-1072 : FCM 푸시 토큰 등록 누락 지점 수정

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -135,18 +135,12 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
         }
     }
 
-    /**
-     * 위치 권한과 함께 요청할 권한 목록.
-     *
-     * Android 13+의 알림 권한은 별도로 요청하면 위치 권한 다이얼로그와 겹쳐 한쪽이 자동 거부될 수 있어,
-     * 시스템이 순차적으로 처리하도록 한 번에 요청한다.
-     */
-    private val startUpPermissions: Array<String>
-        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.POST_NOTIFICATIONS)
-        } else {
-            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
-        }
+    // Android 13+ 알림 권한을 따로 요청하면 위치 권한 다이얼로그와 겹쳐 한쪽이 자동 거부될 수 있어 함께 요청한다.
+    private val startUpPermissions: Array<String> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.POST_NOTIFICATIONS)
+    } else {
+        arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+    }
 
     override fun initView() {
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, homeBackPressedCallback)

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -3,6 +3,7 @@ package com.zion830.threedollars.ui.home.ui
 import android.Manifest
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
@@ -117,10 +118,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
     }
 
     private val locationPermissionLauncher = registerForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { isGranted ->
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { results ->
         when {
-            isGranted -> {
+            results[Manifest.permission.ACCESS_FINE_LOCATION] == true -> {
                 onLocationPermissionGranted()
             }
             shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION) -> {
@@ -133,6 +134,19 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
             }
         }
     }
+
+    /**
+     * 위치 권한과 함께 요청할 권한 목록.
+     *
+     * Android 13+의 알림 권한은 별도로 요청하면 위치 권한 다이얼로그와 겹쳐 한쪽이 자동 거부될 수 있어,
+     * 시스템이 순차적으로 처리하도록 한 번에 요청한다.
+     */
+    private val startUpPermissions: Array<String>
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
 
     override fun initView() {
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, homeBackPressedCallback)
@@ -741,7 +755,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
             }
             shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION) -> {
                 // 이전에 거부했지만 재요청 가능: 바로 권한 요청
-                locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                locationPermissionLauncher.launch(startUpPermissions)
             }
             hasRequestedLocationPermission -> {
                 // "다시 묻지 않음" 상태: 설명 다이얼로그
@@ -750,7 +764,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
             else -> {
                 // 첫 요청: 바로 권한 요청
                 hasRequestedLocationPermission = true
-                locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                locationPermissionLauncher.launch(startUpPermissions)
             }
         }
     }
@@ -794,7 +808,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
                 dialog.dismiss()
                 if (shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)) {
                     // 재요청 가능한 상태: 권한 요청
-                    locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                    locationPermissionLauncher.launch(startUpPermissions)
                 } else {
                     // "다시 묻지 않음" 상태: 설정 페이지로
                     requireContext().goToPermissionSetting()

--- a/app/src/main/java/com/zion830/threedollars/ui/splash/ui/SplashActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/splash/ui/SplashActivity.kt
@@ -30,6 +30,7 @@ import com.zion830.threedollars.ui.login.ui.LoginActivity
 import com.zion830.threedollars.ui.splash.viewModel.SplashViewModel
 import com.zion830.threedollars.ui.storeDetail.boss.ui.BossStoreDetailActivity
 import com.zion830.threedollars.ui.storeDetail.user.ui.StoreDetailActivity
+import com.zion830.threedollars.utils.LegacySharedPrefUtils
 import com.zion830.threedollars.utils.isGpsAvailable
 import com.zion830.threedollars.utils.isLocationAvailable
 import com.zion830.threedollars.utils.showToast
@@ -103,7 +104,14 @@ class SplashActivity :
         }
     }
 
+    /**
+     * 푸시 토큰 등록은 인증이 필요한 API다.
+     * 비로그인 상태에서 호출하면 401이 내려와 세션 만료로 처리되므로 로그인 상태에서만 요청한다.
+     * 비로그인 유저의 토큰은 로그인에 성공하는 시점에 등록된다.
+     */
     private fun initPushToken() {
+        if (LegacySharedPrefUtils.getAccessToken().isNullOrBlank()) return
+
         FirebaseMessaging.getInstance().token.addOnCompleteListener {
             if (it.isSuccessful) {
                 viewModel.putPushInformation(PushInformationRequest(pushToken = it.result))

--- a/app/src/main/java/com/zion830/threedollars/ui/splash/ui/SplashActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/splash/ui/SplashActivity.kt
@@ -104,11 +104,7 @@ class SplashActivity :
         }
     }
 
-    /**
-     * 푸시 토큰 등록은 인증이 필요한 API다.
-     * 비로그인 상태에서 호출하면 401이 내려와 세션 만료로 처리되므로 로그인 상태에서만 요청한다.
-     * 비로그인 유저의 토큰은 로그인에 성공하는 시점에 등록된다.
-     */
+    // 푸시 토큰 등록은 인증이 필요한 API라 비로그인 상태에서 호출하면 401이 내려온다. 토큰은 로그인 성공 시점에 등록된다.
     private fun initPushToken() {
         if (LegacySharedPrefUtils.getAccessToken().isNullOrBlank()) return
 

--- a/app/src/main/java/com/zion830/threedollars/utils/ThreedollarsMessagingService.kt
+++ b/app/src/main/java/com/zion830/threedollars/utils/ThreedollarsMessagingService.kt
@@ -9,13 +9,47 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.threedollar.common.utils.SharedPrefUtils
+import com.threedollar.domain.login.repository.LoginRepository
 import com.zion830.threedollars.DynamicLinkActivity
 import com.zion830.threedollars.R
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 
+@AndroidEntryPoint
 class ThreedollarsMessagingService : FirebaseMessagingService() {
+
+    @Inject
+    lateinit var loginRepository: LoginRepository
+
+    @Inject
+    lateinit var sharedPrefUtils: SharedPrefUtils
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * 재설치, 앱 데이터 복원, 토큰 만료 등으로 FCM 토큰이 회전되면 호출된다.
+     * 갱신된 토큰을 서버에 다시 등록하지 않으면 해당 기기는 푸시 발송 대상에서 빠진다.
+     */
     override fun onNewToken(token: String) {
         super.onNewToken(token)
+        if (sharedPrefUtils.getAccessToken().isNullOrBlank()) return
+
+        serviceScope.launch {
+            loginRepository.putPushInformation(token).collect()
+        }
+    }
+
+    override fun onDestroy() {
+        serviceScope.cancel()
+        super.onDestroy()
     }
 
     override fun onMessageReceived(message: RemoteMessage) {

--- a/app/src/main/java/com/zion830/threedollars/utils/ThreedollarsMessagingService.kt
+++ b/app/src/main/java/com/zion830/threedollars/utils/ThreedollarsMessagingService.kt
@@ -9,7 +9,6 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.threedollar.common.utils.SharedPrefUtils
 import com.threedollar.domain.login.repository.LoginRepository
 import com.zion830.threedollars.DynamicLinkActivity
 import com.zion830.threedollars.R
@@ -29,18 +28,12 @@ class ThreedollarsMessagingService : FirebaseMessagingService() {
     @Inject
     lateinit var loginRepository: LoginRepository
 
-    @Inject
-    lateinit var sharedPrefUtils: SharedPrefUtils
-
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    /**
-     * 재설치, 앱 데이터 복원, 토큰 만료 등으로 FCM 토큰이 회전되면 호출된다.
-     * 갱신된 토큰을 서버에 다시 등록하지 않으면 해당 기기는 푸시 발송 대상에서 빠진다.
-     */
+    // 회전된 FCM 토큰을 서버에 다시 등록하지 않으면 해당 기기가 푸시 발송 대상에서 빠진다.
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        if (sharedPrefUtils.getAccessToken().isNullOrBlank()) return
+        if (LegacySharedPrefUtils.getAccessToken().isNullOrBlank()) return
 
         serviceScope.launch {
             loginRepository.putPushInformation(token).collect()


### PR DESCRIPTION
## 결론

iOS와 비교한 결과 **차이가 있어 작업했습니다.** Firebase 프로젝트 설정(`google-services.json`), 등록 API(`PUT /api/v2/device`), 요청 바디 스키마는 iOS와 동일했고, 문제는 **클라이언트에서 토큰을 등록하는 시점과 조건**이었습니다. 아래 3가지가 Android에만 있는 누락입니다.

## 원인

### 1. Android 13+ 알림 권한을 사실상 요청하지 않음 (대상자 수 격차의 유력 원인)

`AndroidManifest.xml`에 `POST_NOTIFICATIONS` 선언은 있지만, 런타임 요청 코드는 `SystemUtils.kt`의 `requestPermissionFirst()` 한 곳뿐입니다.

```kotlin
fun Activity.requestPermissionFirst(permission: String = ACCESS_FINE_LOCATION) {
    if (LegacySharedPrefUtils.isFirstPermissionCheck()) {
        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
            ActivityCompat.requestPermissions(this, arrayOf(permission, POST_NOTIFICATIONS), 0)
```

그런데 이 함수의 **유일한 호출처가 `FavoriteViewerActivity`** — 공유 링크로 진입하는 즐겨찾기 뷰어 화면입니다. 스플래시·메인·홈 어디서도 호출되지 않습니다. 홈의 위치 권한 흐름(`HomeFragment`)은 `ACCESS_FINE_LOCATION`만 요청합니다.

게다가 `isFirstPermissionCheck()`는 읽는 순간 플래그를 소비하므로, 위치 권한 쪽에서 먼저 소비되면 알림 권한 요청 기회는 영영 사라집니다.

결과적으로 **Android 13+ 유저 대부분이 알림 권한 미허용 상태**로 남습니다.

iOS는 `AppDelegate.didFinishLaunchingWithOptions`에서 매 실행마다 `UNUserNotificationCenter.requestAuthorization` + `registerForRemoteNotifications()`를 호출합니다.

### 2. `onNewToken`이 빈 구현

`ThreedollarsMessagingService.kt`

```kotlin
override fun onNewToken(token: String) {
    super.onNewToken(token)
}
```

재설치, 앱 데이터 복원, 토큰 만료 등으로 FCM 토큰이 회전되면 **서버에 아무것도 보내지 않아** 해당 기기가 발송 대상에서 빠집니다. 기존에 등록된 서버 토큰은 죽은 토큰으로 남습니다.

iOS는 `MessagingDelegate.didReceiveRegistrationToken`에서 회전 토큰을 항상 받아 `Preference.fcmToken`에 반영합니다.

### 3. 비로그인 상태에서 토큰 등록을 시도해 401 발생

`SplashActivity.initPushToken()`은 로그인 여부와 무관하게 호출됩니다. `PUT /api/v2/device`는 인증이 필요한 API인데, 비로그인 상태에서는 `NetworkModule`의 인터셉터가 빈 `Authorization` 헤더를 붙여 401이 내려옵니다. 그러면 `Authenticator`가 `GlobalEvent.triggerLogout()`을 호출합니다.

iOS는 `SplashViewModel`에서 **토큰 검증 성공 후에만** 등록을 호출해 이 부작용이 없습니다.

## 수정 방향

**수정 내용:**
- `HomeFragment.kt`: 권한 런처를 `RequestPermission()` → `RequestMultiplePermissions()`로 바꾸고, Android 13+에서는 위치 권한과 알림 권한을 **한 번에** 요청. 별도 요청으로 두면 두 다이얼로그가 겹쳐 한쪽이 자동 거부될 수 있어 시스템이 순차 처리하도록 묶었습니다. 위치 권한 분기 로직은 그대로 유지했습니다.
- `ThreedollarsMessagingService.kt`: `@AndroidEntryPoint` + `LoginRepository` 주입. `onNewToken`에서 로그인 상태일 때 갱신 토큰을 서버에 재등록.
- `SplashActivity.kt`: 액세스 토큰이 없으면 푸시 토큰 등록을 건너뜀. 비로그인 유저의 토큰은 기존대로 로그인 성공 시점(`LoginActivity`, `LoginRequestDialog`, `SignUpActivity`)에 등록됩니다.

## 검증

- ✅ `./gradlew :app:assembleDebug` BUILD SUCCESSFUL
- ✅ Hilt 주입 코드 생성 확인 (`_com_zion830_threedollars_utils_ThreedollarsMessagingService_GeneratedInjector`)
- 수동 확인 필요:
  1. Android 13+ 기기에서 앱 신규 설치 후 첫 홈 진입 → 위치 권한 다이얼로그 다음에 알림 권한 다이얼로그가 뜨는지, 위치 권한 결과가 기존과 동일하게 처리되는지
  2. 로그인 상태에서 앱 데이터 삭제 후 재로그인 → `PUT /api/v2/device` 호출 확인
  3. 비로그인 상태로 앱 실행 → `PUT /api/v2/device` 호출이 없고 401도 발생하지 않는지
  4. 배포 후 Firebase 콘솔에서 Android 대상자 수 추이 확인 (알림 권한은 기존 설치 유저에게도 다음 홈 진입 시 1회 요청됨)

## 영향 범위

- 신규/기존 Android 13+ 유저에게 알림 권한 다이얼로그가 1회 노출됩니다. **유저에게 보이는 변화가 있는 항목이라 배포 전 기획 확인을 권장합니다.**
- **리스크:** 중간 — 홈 진입 시 권한 요청 흐름이 바뀝니다. 위치 권한 처리 분기 자체는 변경하지 않았습니다.
- 참고: `SplashActivity`의 401 제거는 TH-821(세션 만료 시 로그인 화면 이동)과 맞물립니다. TH-821이 머지되면 401 → 로그인 화면 이동이 실제로 동작하게 되므로, 이 수정이 없으면 **비로그인 유저가 앱 실행 시 "세션이 만료되었습니다" 안내를 받는 문제**가 생깁니다. 두 PR을 함께 머지해 주세요.
- 이번 범위에서 다루지 않은 것:
  - 마케팅 수신 대상 FCM topic(`marketing_aos`)의 서버 이관은 TH-539에서 별도로 다루는 것으로 확인했습니다.
  - iOS는 등록 실패를 Crashlytics에 기록하고 `isPushGranted` 유저 프로퍼티를 계측하지만 Android에는 없습니다. 계측이 없어 이번 문제가 오래 드러나지 않았으므로 추가를 권장합니다.

## 관련 이슈

- Jira: TH-1072