### PR TITLE
ci: Firebase 개발버전 배포에 수동 트리거 추가

### DIFF
--- a/.github/workflows/firebase-distribution.yml
+++ b/.github/workflows/firebase-distribution.yml
@@ -6,13 +6,19 @@ on:
       - 'release/**'
     types:
       - closed
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: '배포 노트 (비우면 해당 브랜치 최근 커밋 20개를 사용)'
+        required: false
+        type: string
 
 env:
   JAVA_VERSION: '17'
 
 jobs:
   build-and-distribute:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -61,26 +67,49 @@ jobs:
           APK_PATH=$(find app/build/outputs/apk -name "*.apk" -type f | head -1)
           echo "path=$APK_PATH" >> $GITHUB_OUTPUT
 
-      - name: Get PR commits for release notes
+      - name: Build release notes
         id: release_notes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          MANUAL_NOTES: ${{ github.event.inputs.release_notes }}
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
-
-          COMMITS=$(git log --pretty=format:"- %s" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | head -20)
-
           VERSION=$(grep "version_name=" gradle.properties | cut -d'=' -f2)
 
-          RELEASE_NOTES="PR #${PR_NUMBER}: ${PR_TITLE}
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            HEADLINE="수동 배포: ${GITHUB_REF_NAME}"
+            SOURCE="$GITHUB_REF_NAME"
+            LINK="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            if [ -n "$MANUAL_NOTES" ]; then
+              BODY="$MANUAL_NOTES"
+            else
+              BODY=$(git log --pretty=format:"- %s" -20)
+            fi
+          else
+            HEADLINE="PR #${PR_NUMBER}: ${PR_TITLE}"
+            SOURCE="$BASE_REF"
+            LINK="$PR_URL"
+            BODY=$(git log --pretty=format:"- %s" "${BASE_SHA}..${HEAD_SHA}" | head -20)
+          fi
+
+          RELEASE_NOTES="${HEADLINE}
           Version: ${VERSION}
 
           Changes:
-          ${COMMITS}"
+          ${BODY}"
 
           echo "notes<<EOF" >> $GITHUB_OUTPUT
           echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "headline=$HEADLINE" >> $GITHUB_OUTPUT
+          echo "source=$SOURCE" >> $GITHUB_OUTPUT
+          echo "link=$LINK" >> $GITHUB_OUTPUT
 
       - name: Upload to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1
@@ -110,14 +139,14 @@ jobs:
                   "type": "section",
                   "fields": [
                     {"type": "mrkdwn", "text": "*Version:*\n${{ steps.release_notes.outputs.version }}"},
-                    {"type": "mrkdwn", "text": "*Branch:*\n${{ github.event.pull_request.base.ref }}"}
+                    {"type": "mrkdwn", "text": "*Branch:*\n${{ steps.release_notes.outputs.source }}"}
                   ]
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*PR:* <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}>"
+                    "text": "*Source:* <${{ steps.release_notes.outputs.link }}|${{ steps.release_notes.outputs.headline }}>"
                   }
                 }
               ]
@@ -132,28 +161,26 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           RELEASE_VERSION: ${{ steps.release_notes.outputs.version }}
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          SOURCE_BRANCH: ${{ steps.release_notes.outputs.source }}
+          HEADLINE: ${{ steps.release_notes.outputs.headline }}
+          SOURCE_URL: ${{ steps.release_notes.outputs.link }}
         run: |
           PAYLOAD=$(jq -n \
             --arg version "$RELEASE_VERSION" \
-            --arg branch "$BASE_BRANCH" \
-            --arg pr_number "$PR_NUMBER" \
-            --arg pr_title "$PR_TITLE" \
-            --arg pr_url "$PR_URL" \
+            --arg branch "$SOURCE_BRANCH" \
+            --arg headline "$HEADLINE" \
+            --arg source_url "$SOURCE_URL" \
             '{
               username: "가슴속삼천원 배포 알림",
               allowed_mentions: {parse: []},
               embeds: [{
                 title: "Firebase App Distribution 배포 완료",
                 color: 3066993,
-                url: $pr_url,
+                url: $source_url,
                 fields: [
                   {name: "Version", value: $version, inline: true},
                   {name: "Branch", value: $branch, inline: true},
-                  {name: "PR", value: ("#" + $pr_number + " " + $pr_title), inline: false}
+                  {name: "Source", value: $headline, inline: false}
                 ]
               }]
             }')


### PR DESCRIPTION
## 배경

개발버전(Firebase App Distribution) 배포가 `release/**` 대상 PR merge로만 트리거됩니다. 임의 브랜치로 dev 빌드를 뽑으려면 릴리즈 브랜치에 PR을 만들어 머지하는 수밖에 없었습니다.

## 변경

- `workflow_dispatch` 트리거 추가. 브랜치를 골라 수동 실행할 수 있습니다.
- 선택 입력 `release_notes` 추가. 비우면 해당 브랜치 최근 커밋 20개를 사용합니다.
- job 조건을 `github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true` 로 확장.
- 릴리즈 노트 생성 스텝을 이벤트별로 분기. PR 이벤트는 기존과 동일하게 `base..head` 커밋을 쓰고, 수동 실행은 브랜치명 + 최근 커밋(또는 입력값)을 씁니다.
- Slack·Discord 알림이 `github.event.pull_request.*` 를 직접 참조하던 부분을 스텝 output(`headline`/`source`/`link`)으로 교체했습니다. 수동 실행에서 빈 값이 나가지 않게 하기 위함입니다.

기존 PR merge 경로의 동작은 그대로입니다.

## 참고

`workflow_dispatch`는 워크플로 파일이 기본 브랜치(`develop`)에 있어야 실행 가능합니다. 이 PR이 머지되어야 수동 실행이 가능해집니다.

## 검증

- YAML 파싱 확인 (트리거 2개, dispatch input 1개, step 14개)
- 실제 수동 실행은 머지 후에만 가능해 아직 검증하지 못했습니다.