### PR TITLE
ci: 개발버전 배포 Discord 알림을 iOS 형태로 통일

### DIFF
--- a/.github/workflows/firebase-distribution.yml
+++ b/.github/workflows/firebase-distribution.yml
@@ -80,6 +80,7 @@ jobs:
           MANUAL_NOTES: ${{ github.event.inputs.release_notes }}
         run: |
           VERSION=$(grep "version_name=" gradle.properties | cut -d'=' -f2)
+          VERSION_CODE=$(grep -E '^version_code=' gradle.properties | cut -d'=' -f2)
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             HEADLINE="수동 배포: ${GITHUB_REF_NAME}"
@@ -107,6 +108,7 @@ jobs:
           echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
           echo "headline=$HEADLINE" >> $GITHUB_OUTPUT
           echo "source=$SOURCE" >> $GITHUB_OUTPUT
           echo "link=$LINK" >> $GITHUB_OUTPUT
@@ -160,30 +162,50 @@ jobs:
         continue-on-error: true
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          RELEASE_VERSION: ${{ steps.release_notes.outputs.version }}
-          SOURCE_BRANCH: ${{ steps.release_notes.outputs.source }}
-          HEADLINE: ${{ steps.release_notes.outputs.headline }}
+          VERSION: ${{ steps.release_notes.outputs.version }}
+          BUILD: ${{ steps.release_notes.outputs.version_code }}
+          BRANCH: ${{ steps.release_notes.outputs.source }}
+          WORKFLOW: ${{ github.workflow }}
           SOURCE_URL: ${{ steps.release_notes.outputs.link }}
         run: |
-          PAYLOAD=$(jq -n \
-            --arg version "$RELEASE_VERSION" \
-            --arg branch "$SOURCE_BRANCH" \
-            --arg headline "$HEADLINE" \
-            --arg source_url "$SOURCE_URL" \
-            '{
-              username: "가슴속삼천원 배포 알림",
-              allowed_mentions: {parse: []},
-              embeds: [{
-                title: "Firebase App Distribution 배포 완료",
-                color: 3066993,
-                url: $source_url,
-                fields: [
-                  {name: "Version", value: $version, inline: true},
-                  {name: "Branch", value: $branch, inline: true},
-                  {name: "Source", value: $headline, inline: false}
-                ]
-              }]
-            }')
+          SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+          COMMIT_MSG="$(git log -1 --pretty=%B)"
+
+          PAYLOAD="$(VERSION="$VERSION" BUILD="$BUILD" BRANCH="$BRANCH" \
+            WORKFLOW="$WORKFLOW" SHORT_SHA="$SHORT_SHA" COMMIT_MSG="$COMMIT_MSG" \
+            SOURCE_URL="$SOURCE_URL" \
+            python3 - <<'PY'
+          import os, json
+
+          version  = os.environ.get("VERSION") or "-"
+          build    = os.environ.get("BUILD") or "-"
+          branch   = os.environ.get("BRANCH") or "-"
+          workflow = os.environ.get("WORKFLOW") or "-"
+          sha      = os.environ.get("SHORT_SHA") or "-"
+          url      = os.environ.get("SOURCE_URL") or ""
+          # Discord embed description은 4096자 제한이라 넉넉히 자른다
+          msg      = (os.environ.get("COMMIT_MSG") or "").strip()[:1500] or "-"
+
+          embed = {
+              "title": "🤖 [AOS] Firebase App Distribution 업로드",
+              "color": 5814783,
+              "fields": [
+                  {"name": "버전",       "value": f"{version} ({build})", "inline": True},
+                  {"name": "브랜치",     "value": branch,                 "inline": True},
+                  {"name": "워크플로우", "value": workflow,               "inline": True},
+              ],
+              "description": f"**커밋** `{sha}`\n```\n{msg}\n```",
+          }
+          if url:
+              embed["url"] = url
+
+          print(json.dumps({
+              "username": "GitHub Actions",
+              "allowed_mentions": {"parse": []},
+              "embeds": [embed],
+          }))
+          PY
+          )"
 
           curl --fail-with-body --silent --show-error --retry 2 \
             --header "Content-Type: application/json" \
@@ -225,11 +247,12 @@ jobs:
           PAYLOAD=$(jq -n \
             --arg workflow_url "$WORKFLOW_URL" \
             '{
-              username: "가슴속삼천원 배포 알림",
+              username: "GitHub Actions",
               allowed_mentions: {parse: []},
               embeds: [{
-                title: "Firebase App Distribution 배포 실패",
+                title: "❌ [AOS] Firebase App Distribution 실패",
                 color: 15158332,
+                url: $workflow_url,
                 description: ("[워크플로 실행 결과 확인](" + $workflow_url + ")")
               }]
             }')


### PR DESCRIPTION
## 배경

iOS는 Xcode Cloud 후처리 스크립트(`ci_scripts/ci_post_xcodebuild.sh`)에서 Discord embed로 배포 알림을 보냅니다. Android 개발버전 배포 알림이 다른 형태여서 같은 채널에 섞여 올라올 때 포맷이 어긋납니다. iOS 쪽에 맞췄습니다.

## 변경 (firebase-distribution.yml)

**성공 알림 embed를 iOS와 동일한 구조로 교체**

| 항목 | iOS | 변경 후 Android |
|---|---|---|
| username | `Xcode Cloud` | `GitHub Actions` |
| title | 🧪 [iOS] TestFlight 빌드 업로드 | 🤖 [AOS] Firebase App Distribution 업로드 |
| color | 5814783 | 5814783 (동일) |
| fields | 버전 / 브랜치 / 워크플로우 (전부 inline) | 동일 |
| 버전 표기 | `1.2.3 (45)` | `4.20.0 (123)` — version_name (version_code) |
| description | `**커밋** \`sha\`` + 코드블록 커밋 메시지 | 동일 |

- 페이로드 생성을 `jq` → `python3`로 변경했습니다. iOS 스크립트와 같은 방식이고, 커밋 메시지의 따옴표·줄바꿈·백틱 이스케이프가 안전합니다. 메시지는 iOS와 동일하게 1500자에서 자릅니다.
- `version_code`를 릴리즈 노트 스텝 output에 추가했습니다.
- 실패 알림도 title을 `❌ [AOS] Firebase App Distribution 실패`로 맞추고 username을 통일했습니다.

Slack 알림은 손대지 않았습니다. Discord embed 구조를 Slack block에 그대로 옮길 수 없고, iOS도 Discord만 보냅니다.

## 검증

- YAML 파싱 확인 (steps 14개, Notify 스텝 4개)
- **워크플로에서 스크립트를 추출해 로컬 실행**, 생성된 JSON이 iOS 구조와 일치하는지 확인했습니다 (heredoc 들여쓰기가 YAML 블록 스칼라에서 깨지기 쉬워 실제 실행으로 검증)

```json
{"username": "GitHub Actions",
 "embeds": [{"title": "🤖 [AOS] Firebase App Distribution 업로드",
   "color": 5814783,
   "fields": [{"name": "버전", "value": "4.20.0 (123)", "inline": true},
              {"name": "브랜치", "value": "tmp/dev-build-4pr", "inline": true},
              {"name": "워크플로우", "value": "Firebase App Distribution", "inline": true}],
   "description": "**커밋** \`9369b76\`\n```\n...\n```"}]}
```

- 실제 Discord 발송은 머지 후 배포를 돌려야 확인 가능합니다.

## 참고

description의 커밋 메시지는 체크아웃된 HEAD 기준입니다. PR 머지 경로나 여러 브랜치를 묶은 temp 브랜치에서는 머지 커밋 메시지가 찍힐 수 있습니다. iOS도 동일하게 마지막 커밋을 쓰고, 상세 변경 목록은 Firebase 릴리즈 노트에 따로 들어갑니다.

`play-internal-release.yml`의 Discord 알림은 이번 범위(개발버전 배포)가 아니라 그대로 뒀습니다. 같이 맞출지는 알려주세요.