### PR TITLE
TH-1252 홈 지도 초기 줌 레벨 적용

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -422,6 +422,11 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
                     }
                 }
                 launch {
+                    viewModel.initialMapZoomLevel.collect { zoomLevel ->
+                        zoomLevel?.let { naverMapFragment.applyInitialZoomLevel(it) }
+                    }
+                }
+                launch {
                     searchViewModel.searchResultLocation.collect {
                         naverMapFragment.moveCamera(it)
                         binding.tvAddress.text =

--- a/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
@@ -82,6 +82,10 @@ class HomeViewModel @Inject constructor(
     private val _filterCells = MutableStateFlow<List<HomeFilterCellType>>(emptyList())
     val filterCells: StateFlow<List<HomeFilterCellType>> = _filterCells.asStateFlow()
 
+    /** 서버가 내려준 홈 지도 최초 줌 레벨. 응답이 없거나 설정값이 없으면 null이다. */
+    private val _initialMapZoomLevel = MutableStateFlow<Double?>(null)
+    val initialMapZoomLevel: StateFlow<Double?> = _initialMapZoomLevel.asStateFlow()
+
     private val _filterDeepLink = MutableSharedFlow<SDLinkModel>(extraBufferCapacity = 1)
     val filterDeepLink: SharedFlow<SDLinkModel> = _filterDeepLink.asSharedFlow()
 
@@ -492,13 +496,14 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch(coroutineExceptionHandler) {
             screenRepository.getHomeFilterScreen().collect { response ->
                 if (response.ok && response.data != null) {
-                    val sections = response.data!!.sections
+                    val screen = response.data!!
                     _uiState.update {
                         it.copy(
-                            filterSections = sections,
+                            filterSections = screen.sections,
                             hasLoadedFilterScreen = true,
                         )
                     }
+                    _initialMapZoomLevel.value = screen.configuration?.initialMapZoomLevel
                     initializeRadioSelectionDefaults()
                     updateFilterCells()
                 } else {

--- a/app/src/main/java/com/zion830/threedollars/ui/map/ui/NaverMapFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/map/ui/NaverMapFragment.kt
@@ -99,6 +99,15 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
      */
     private var isInitialCameraPlaced = false
 
+    /**
+     * 서버가 내려준 최초 지도 줌 레벨.
+     *
+     * 첫 카메라 배치보다 응답이 먼저 도착하면 그 배치에 함께 적용하고, 늦게 도착하면 줌만 따로 맞춘다.
+     * 어느 쪽이든 최초 1회만 적용하고, 이후 사용자가 조작한 줌은 건드리지 않는다.
+     */
+    private var initialZoomLevel: Double? = null
+    private var isInitialZoomLevelApplied = false
+
     var onAdMarkerClicked: ((Int) -> Unit)? = null
 
     fun setOnMapTouchListener(mapListener: OnMapTouchListener) {
@@ -546,14 +555,30 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
         isShowOverlay = isVisible
     }
 
+    /**
+     * 서버가 내려준 최초 지도 줌 레벨을 적용한다.
+     *
+     * 아직 첫 카메라 배치 전이면 값만 보관했다가 그 배치에 함께 적용하고,
+     * 이미 배치된 뒤라면 줌만 애니메이션으로 맞춘다.
+     */
+    fun applyInitialZoomLevel(zoomLevel: Double) {
+        if (isInitialZoomLevelApplied) return
+
+        initialZoomLevel = zoomLevel
+        val map = naverMap
+        if (isInitialCameraPlaced && map != null) {
+            isInitialZoomLevelApplied = true
+            map.moveCamera(CameraUpdate.zoomTo(zoomLevel).animate(CameraAnimation.Easing))
+        }
+    }
+
     fun moveCamera(position: LatLng) {
         if (naverMap == null) {
             return
         }
 
         isInitialCameraPlaced = true
-        val cameraUpdate = CameraUpdate.scrollTo(position)
-        naverMap?.moveCamera(cameraUpdate)
+        naverMap?.moveCamera(cameraUpdateForMove(position))
     }
 
     fun moveCameraWithAnim(position: LatLng) {
@@ -562,8 +587,17 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
         }
 
         isInitialCameraPlaced = true
-        val cameraUpdate = CameraUpdate.scrollTo(position).animate(CameraAnimation.Easing)
-        naverMap?.moveCamera(cameraUpdate)
+        naverMap?.moveCamera(cameraUpdateForMove(position).animate(CameraAnimation.Easing))
+    }
+
+    private fun cameraUpdateForMove(position: LatLng): CameraUpdate {
+        val zoomLevel = initialZoomLevel
+        if (isInitialZoomLevelApplied || zoomLevel == null) {
+            return CameraUpdate.scrollTo(position)
+        }
+
+        isInitialZoomLevelApplied = true
+        return CameraUpdate.scrollAndZoomTo(position, zoomLevel)
     }
 
     open fun onMyLocationLoaded(position: LatLng) {

--- a/core/common/src/main/java/com/threedollar/common/serverdriven/model/HomeFilterModels.kt
+++ b/core/common/src/main/java/com/threedollar/common/serverdriven/model/HomeFilterModels.kt
@@ -35,7 +35,17 @@ enum class FilterOpenStatuses {
 
 data class HomeFilterScreenModel(
     val sections: List<HomeScreenSection> = emptyList(),
+    val configuration: HomeFilterConfiguration? = null,
     val viewLog: SDViewLogModel? = null,
+)
+
+/**
+ * 홈 화면 동작을 서버에서 제어하는 설정값.
+ *
+ * @property initialMapZoomLevel 홈 지도의 최초 줌 레벨. 값이 없으면 지도 SDK 기본 줌을 유지한다.
+ */
+data class HomeFilterConfiguration(
+    val initialMapZoomLevel: Double? = null,
 )
 
 sealed interface HomeScreenSection {

--- a/core/network/src/main/java/com/threedollar/network/data/screen/HomeFilterScreenResponse.kt
+++ b/core/network/src/main/java/com/threedollar/network/data/screen/HomeFilterScreenResponse.kt
@@ -6,8 +6,15 @@ import com.google.gson.annotations.SerializedName
 data class HomeFilterScreenResponse(
     @SerializedName("sections")
     val sections: List<HomeFilterSectionResponse>? = emptyList(),
+    @SerializedName("configuration")
+    val configuration: HomeFilterConfigurationResponse? = null,
     @SerializedName("viewLog")
     val viewLog: HomeFilterViewLogResponse? = null,
+)
+
+data class HomeFilterConfigurationResponse(
+    @SerializedName("initialMapZoomLevel")
+    val initialMapZoomLevel: Double? = null,
 )
 
 data class HomeFilterViewLogResponse(

--- a/data/src/main/java/com/threedollar/data/screen/HomeFilterScreenMapper.kt
+++ b/data/src/main/java/com/threedollar/data/screen/HomeFilterScreenMapper.kt
@@ -3,6 +3,7 @@ package com.threedollar.data.screen
 import com.google.gson.JsonElement
 import com.threedollar.common.serverdriven.model.HomeFilterBar
 import com.threedollar.common.serverdriven.model.HomeFilterBarType
+import com.threedollar.common.serverdriven.model.HomeFilterConfiguration
 import com.threedollar.common.serverdriven.model.HomeFilterCurrentCategory
 import com.threedollar.common.serverdriven.model.HomeFilterRadioOption
 import com.threedollar.common.serverdriven.model.HomeFilterScreenModel
@@ -24,6 +25,7 @@ import com.threedollar.network.data.screen.HomeFilterBorderResponse
 import com.threedollar.network.data.screen.HomeFilterButtonResponse
 import com.threedollar.network.data.screen.HomeFilterChipResponse
 import com.threedollar.network.data.screen.HomeFilterClickLogResponse
+import com.threedollar.network.data.screen.HomeFilterConfigurationResponse
 import com.threedollar.network.data.screen.HomeFilterCurrentCategoryResponse
 import com.threedollar.network.data.screen.HomeFilterImageResponse
 import com.threedollar.network.data.screen.HomeFilterImageStyleResponse
@@ -37,7 +39,12 @@ import com.threedollar.network.data.screen.HomeFilterViewLogResponse
 
 fun HomeFilterScreenResponse.asModel(): HomeFilterScreenModel = HomeFilterScreenModel(
     sections = sections.orEmpty().map { it.asModel() },
+    configuration = configuration?.asModel(),
     viewLog = viewLog?.asModelOrNull(),
+)
+
+private fun HomeFilterConfigurationResponse.asModel(): HomeFilterConfiguration = HomeFilterConfiguration(
+    initialMapZoomLevel = initialMapZoomLevel,
 )
 
 private fun HomeFilterSectionResponse.asModel(): HomeScreenSection {

--- a/data/src/test/java/com/threedollar/data/screen/HomeFilterScreenMapperTest.kt
+++ b/data/src/test/java/com/threedollar/data/screen/HomeFilterScreenMapperTest.kt
@@ -6,6 +6,7 @@ import com.threedollar.common.serverdriven.model.HomeScreenSection
 import com.threedollar.network.data.screen.HomeFilterBarResponse
 import com.threedollar.network.data.screen.HomeFilterChipResponse
 import com.threedollar.network.data.screen.HomeFilterClickLogResponse
+import com.threedollar.network.data.screen.HomeFilterConfigurationResponse
 import com.threedollar.network.data.screen.HomeFilterImageResponse
 import com.threedollar.network.data.screen.HomeFilterImageStyleResponse
 import com.threedollar.network.data.screen.HomeFilterScreenResponse
@@ -13,6 +14,7 @@ import com.threedollar.network.data.screen.HomeFilterSectionResponse
 import com.threedollar.network.data.screen.HomeFilterTextResponse
 import com.threedollar.network.data.screen.HomeFilterViewLogResponse
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class HomeFilterScreenMapperTest {
@@ -88,5 +90,21 @@ class HomeFilterScreenMapperTest {
         val categoryBar = section.bars.single() as HomeFilterBar.CategoryBar
 
         assertEquals(longStoreId, categoryBar.categoriesFilterClickLog?.extraParameters?.get("STORE_ID")?.anyValue)
+    }
+
+    @Test
+    fun homeFilterMapper_mapsInitialMapZoomLevel() {
+        val response = HomeFilterScreenResponse(
+            configuration = HomeFilterConfigurationResponse(initialMapZoomLevel = 15.0),
+        )
+
+        assertEquals(15.0, response.asModel().configuration?.initialMapZoomLevel)
+    }
+
+    @Test
+    fun homeFilterMapper_keepsNullConfigurationWhenResponseHasNone() {
+        val response = HomeFilterScreenResponse()
+
+        assertNull(response.asModel().configuration)
     }
 }


### PR DESCRIPTION
## 변경 사항

- 홈 화면 응답의 `configuration.initialMapZoomLevel`을 디코딩합니다. (`HomeFilterScreenResponse` → `HomeFilterScreenModel`)
- 응답값을 홈 지도에 전달해 Naver Map SDK의 `CameraUpdate.scrollAndZoomTo`로 최초 카메라 배치에 적용합니다.
- 서버 설정값이 없는 이전 응답은 기존 동작(지도 SDK 기본 줌)을 유지합니다.

iOS([#316](https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/pull/316))는 위치와 필터 응답을 모두 기다린 뒤 최초 카메라를 이동합니다.
Android는 최초 카메라 배치 경로가 두 곳(`NearStoreNaverMapFragment.onMapReady` 첫 로드 / 권한 확인 후 현재 위치 이동)이라, 응답을 기다려 지도를 멈추는 대신 `NaverMapFragment`가 최초 1회만 줌 레벨을 적용하도록 했습니다.
응답이 카메라 배치보다 먼저 도착하면 그 배치에 함께 적용하고, 늦게 도착하면 줌만 애니메이션으로 맞춥니다. 이후 사용자가 조작한 줌은 건드리지 않습니다.

## 검증

- `./gradlew :app:assembleDebug` 성공
- `./gradlew :data:testDebugUnitTest --tests "com.threedollar.data.screen.HomeFilterScreenMapperTest"` 성공 (`configuration` 매핑 테스트 2개 추가)
- 개발 서버 `GET /api/v1/screen/home` 응답: `configuration.initialMapZoomLevel: 15.0`
- Android 에뮬레이터(API 36, 1080x2400)에서 위치를 서울시청(37.5665, 126.9780)으로 고정하고 develop / 서버 응답 15.0 / 제어값 13.0의 최초 줌이 다르게 적용되는 것을 확인

## 스크린샷

| develop (적용 전) | 서버 응답: 15.0 | 제어 응답값: 13.0 |
|:---:|:---:|:---:|
| ![develop 적용 전](https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/download/verification-assets/TH-1252-before-develop.png) | ![서버 응답 15.0](https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/download/verification-assets/TH-1252-server-zoom-15.png) | ![제어 응답값 13.0](https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/download/verification-assets/TH-1252-controlled-zoom-13.png) |

13.0은 서버 관리값을 변경하지 않기 위해 동일한 응답 전달 경로에 일시 주입해 검증했으며, 최종 코드에는 포함하지 않았습니다. 검증 이미지는 [verification-assets prerelease](https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-android/releases/tag/verification-assets)에 보관합니다.

https://3dollarinmypocket.atlassian.net/browse/TH-1252

https://claude.ai/code/session_017nFkmruPfFAe2ajVBmMotV
