### PR TITLE
ci: 릴리즈 브랜치 푸시 시 Play Store production 초안 업로드

### DIFF
--- a/.github/workflows/play-production-release.yml
+++ b/.github/workflows/play-production-release.yml
@@ -1,0 +1,109 @@
+name: Play Production Release (Draft)
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+permissions:
+  contents: read
+
+env:
+  JAVA_VERSION: '17'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read release version
+        id: version
+        run: |
+          VERSION_NAME=$(grep -E '^version_name=' gradle.properties | cut -d'=' -f2)
+          VERSION_CODE=$(grep -E '^version_code=' gradle.properties | cut -d'=' -f2)
+
+          if [ -z "$VERSION_NAME" ] || [ -z "$VERSION_CODE" ]; then
+            echo "version_name/version_code missing from gradle.properties" >&2
+            exit 1
+          fi
+
+          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+          echo "tag_name=v${VERSION_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Decode Keystore
+        run: |
+          printf '%s' "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > app/3dollor-android-key.jks
+
+      - name: Create local.properties
+        run: |
+          cat > local.properties <<EOF
+          sdk.dir=${ANDROID_HOME}
+          google_map_key=${{ secrets.GOOGLE_MAP_KEY }}
+          nmf_client_id=${{ secrets.NMF_CLIENT_ID }}
+          admob_id=${{ secrets.ADMOB_ID }}
+          kakao_key_dev=${{ secrets.KAKAO_KEY_DEV }}
+          kakao_map_key=${{ secrets.KAKAO_MAP_KEY }}
+          develop_url=${{ secrets.DEVELOP_URL }}
+          deep_link=${{ secrets.DEEP_LINK }}
+          application_id_dev=${{ secrets.APPLICATION_ID_DEV }}
+          kakao_key_release=${{ secrets.KAKAO_KEY_RELEASE }}
+          kakao_map_key_release=${{ secrets.KAKAO_MAP_KEY_RELEASE }}
+          release_url=${{ secrets.RELEASE_URL }}
+          deep_link_release=${{ secrets.DEEP_LINK_RELEASE }}
+          EOF
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build release AAB
+        run: ./gradlew bundleRelease --no-daemon --stacktrace
+
+      - name: Verify AAB
+        id: artifacts
+        run: |
+          RELEASE_AAB="app/build/outputs/bundle/release/app-release.aab"
+          test -f "$RELEASE_AAB"
+          echo "release_aab=$RELEASE_AAB" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare release notes
+        run: |
+          PREVIOUS_TAG=$(git tag --list 'v*' --sort=-version:refname | head -n 1 || true)
+          mkdir -p distribution/whatsnew
+
+          COMMITS=""
+          if [ -n "$PREVIOUS_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"- %s" "${PREVIOUS_TAG}..HEAD" || true)
+          fi
+
+          if [ -z "$COMMITS" ]; then
+            COMMITS="- ${{ steps.version.outputs.tag_name }} 릴리즈"
+          fi
+
+          printf '%s\n' "$COMMITS" > distribution/whatsnew/whatsnew-ko-KR
+
+      - name: Upload to Google Play production (draft)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.zion830.threedollars
+          releaseFiles: ${{ steps.artifacts.outputs.release_aab }}
+          tracks: production
+          status: draft
+          releaseName: ${{ steps.version.outputs.tag_name }}
+          whatsNewDirectory: distribution/whatsnew


### PR DESCRIPTION
## Summary
- `release/**` 브랜치에 push되면 트리거되는 GitHub Actions 워크플로 추가
- AAB(`bundleRelease`)를 빌드하고, Google Play **production** 트랙에 **draft(초안)** 상태로 업로드
- 기존 `play-internal-release.yml`과 동일한 keystore/local.properties/서비스 계정 시크릿을 재사용

## 동작 방식
1. `release/**` 브랜치에 push 발생
2. `gradle.properties`의 `version_name`/`version_code`를 읽어 태그명(`v{version_name}`) 계산
3. keystore·local.properties를 시크릿으로 복원 후 `./gradlew bundleRelease` 실행
4. 이전 태그 이후 커밋 로그로 `distribution/whatsnew/whatsnew-ko-KR` 릴리즈 노트 생성
5. `r0adkll/upload-google-play@v1`로 production 트랙에 `status: draft`로 업로드 → Play Console에는 "출시 준비" 초안으로만 저장되고 실제 배포(출시 시작)는 되지 않음

## 주의사항
- Play Console에서 서비스 계정(`GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`)에 production 트랙 릴리즈 권한이 있어야 함 (internal 권한만 있으면 403 발생 가능)
- `version_code`는 Play Store에 이미 사용된 값과 겹치면 실패하므로, release 브랜치 푸시 전 `gradle.properties`의 버전을 미리 올려둬야 함
- draft 상태이므로 실제 사용자에게 배포되지 않으며, Play Console에서 검토 후 수동으로 "검토 후 출시"해야 함

## Test plan
- [ ] YAML 문법 검증 (`ruby -ryaml`으로 확인 완료)
- [ ] `release/**` 네이밍의 테스트용 브랜치(예: `release/v0.0.0-citest`)에 사소한 커밋을 push해 워크플로가 정상 트리거되는지 확인
- [ ] Actions 탭에서 빌드 성공 및 Play Console 업로드 성공 로그 확인
- [ ] Play Console > 프로덕션 트랙에 draft 릴리즈가 생성됐는지 확인 (출시 시작되지 않았는지 확인)
- [ ] 테스트 후 Play Console에서 불필요한 draft 릴리즈 삭제

https://claude.ai/code/session_01SNmfRrs4Btfxs8cfQRopYY