### PR TITLE
ci: Release 발행 시 Discord 릴리즈 알림 워크플로우 추가

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -1,0 +1,43 @@
+name: Discord Release Notify
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    # verification-assets 같은 prerelease는 릴리즈 공지 대상이 아니다
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send to Discord
+        env:
+          # 릴리즈 공지 전용 웹훅이 등록되면 우선 사용하고, 없으면 기존 배포 알림 웹훅으로 보낸다
+          WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL || secrets.DISCORD_WEBHOOK_URL }}
+          TAG: ${{ github.event.release.tag_name }}
+          BODY: ${{ github.event.release.body }}
+          URL: ${{ github.event.release.html_url }}
+        run: |
+          # Discord embed description 제한(4096자)을 넘지 않도록 안전하게 자른다
+          DESC="$(printf '%s' "$BODY" | head -c 3900)"
+
+          # jq로 페이로드를 만들어 shell/JSON 이스케이프(따옴표·백틱·줄바꿈)를 모두 처리한다
+          payload="$(jq -n \
+            --arg tag "$TAG" \
+            --arg desc "$DESC" \
+            --arg url "$URL" \
+            '{
+              content: "@everyone 새 버전 나왔어요! 🎉",
+              allowed_mentions: { parse: ["everyone"] },
+              embeds: [{
+                title: ("🚀 [Android] " + $tag + " 출시!"),
+                description: $desc,
+                url: $url,
+                color: 5814783
+              }]
+            }')"
+
+          # -f: HTTP 4xx/5xx면 step도 실패시켜 알림 누락을 감지한다
+          curl -sf -X POST "$WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$payload"


### PR DESCRIPTION
## 개요
iOS 레포([discord-release-notify.yml](https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/blob/master/.github/workflows/discord-release-notify.yml))와 동일한 형태로, GitHub Release가 발행되면 Discord에 릴리즈 알림을 보내는 워크플로우를 추가합니다.

## 동작
- **트리거**: `release: published` (iOS 워크플로우와 동일 — 태그만 push해서는 발동하지 않고, GitHub Release를 발행하면 발동합니다)
- **메시지 형태**: iOS와 동일한 임베드 — `@everyone 새 버전 나왔어요! 🎉` + `🚀 [Android] v4.x.x 출시!` 제목 + 릴리즈 노트 본문 + 릴리즈 링크
- **prerelease 제외**: PR 검증 스크린샷 호스팅용 `verification-assets` 같은 prerelease는 알림을 보내지 않습니다
- 릴리즈 노트가 Discord embed description 제한(4096자)을 넘지 않도록 3900자에서 자릅니다

<img width="607" height="592" alt="image" src="https://github.com/user-attachments/assets/66ab934f-1b1f-4697-ae08-25df09ee094c" />


## 웹훅 시크릿
- `DISCORD_RELEASE_WEBHOOK_URL` 시크릿이 등록되어 있으면 그쪽으로, 없으면 기존 `DISCORD_WEBHOOK_URL`(배포 알림 채널)로 보냅니다
- **iOS 알림과 같은 채널로 보내려면**: iOS 레포의 `DISCORD_WEBHOOK` 시크릿과 같은 값을 이 레포에 `DISCORD_RELEASE_WEBHOOK_URL`로 등록해주세요. 등록 전까지는 기존 배포 알림 채널로 나갑니다.

## 검증
- YAML 문법 검증 완료
- 워크플로우 실제 발송은 다음 Release 발행 시 확인 필요 (webhook 시크릿 값에 접근할 수 없어 로컬 발송 테스트는 생략)