### PR TITLE
TH-1262 홈 preset 필터 적용 및 focusBounds 지도 이동

### DIFF
--- a/app/src/main/java/com/zion830/threedollars/DynamicLinkActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/DynamicLinkActivity.kt
@@ -34,6 +34,7 @@ class DynamicLinkActivity : AppCompatActivity() {
         const val COMMUNITY = "community"
         const val REVIEW_LIST = "reviewList"
         const val BROWSER = "browser"
+        const val HOME_PRESET = "homePreset"
 
         private const val LINK = "link"
         private const val SCHEME_DOLLARS = "dollars"
@@ -45,6 +46,7 @@ class DynamicLinkActivity : AppCompatActivity() {
         private const val POLL_ID = "pollId"
         private const val ID = "id"
         private const val URL = "url"
+        private const val PRESET = "preset"
 
         fun launch(context: Context, link: String) {
             Intent(context, DynamicLinkActivity::class.java).apply {
@@ -167,6 +169,7 @@ class DynamicLinkActivity : AppCompatActivity() {
             HOME -> {
                 startActivity(MainActivity.getIntent(this).apply {
                     putExtra(HOME, HOME)
+                    deeplink.getQueryParameter(PRESET)?.let { putExtra(HOME_PRESET, it) }
                     flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
                 })
             }

--- a/app/src/main/java/com/zion830/threedollars/MainActivity.kt
+++ b/app/src/main/java/com/zion830/threedollars/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.zion830.threedollars.ui.home.viewModel.HomeViewModel
 import com.zion830.threedollars.ui.my.page.MyPageViewModel
 import com.naver.maps.geometry.LatLng
 import com.zion830.threedollars.core.designsystem.R as DesignSystemR
@@ -49,6 +50,7 @@ class MainActivity : BaseActivity<ActivityHomeBinding, UserInfoViewModel>({ Acti
     override val viewModel: UserInfoViewModel by viewModels()
     private val myPageViewModel: MyPageViewModel by viewModels()
     private val popupViewModel: PopupViewModel by viewModels()
+    private val homeViewModel: HomeViewModel by viewModels()
 
 
     private lateinit var navHostFragment: NavHostFragment
@@ -213,6 +215,9 @@ class MainActivity : BaseActivity<ActivityHomeBinding, UserInfoViewModel>({ Acti
         } else if (intent.getStringExtra(DynamicLinkActivity.HOME).isNotNullOrEmpty()) {
             binding.navView.post {
                 binding.navView.selectedItemId = R.id.navigation_home
+            }
+            intent.getStringExtra(DynamicLinkActivity.HOME_PRESET)?.let { preset ->
+                homeViewModel.applyPreset(preset)
             }
         } else if (intent.hasExtra(DynamicLinkActivity.STORE_PREVIEW)) {
             binding.navView.post {

--- a/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/ui/HomeFragment.kt
@@ -43,6 +43,7 @@ import com.threedollar.common.serverdriven.model.HomeListCardModel
 import com.threedollar.common.serverdriven.model.SDClickLogValue
 import com.threedollar.common.serverdriven.model.SDCustomActionModel
 import com.threedollar.common.serverdriven.model.SDLinkModel
+import com.threedollar.common.serverdriven.model.SDLocationBoundsModel
 import com.threedollar.common.serverdriven.model.StoreActionBarModel
 import com.threedollar.common.serverdriven.model.StoreSectionModel
 import com.threedollar.common.utils.Constants
@@ -92,6 +93,8 @@ import kotlinx.coroutines.launch
 import zion830.com.common.base.onSingleClick
 import com.threedollar.common.R as CommonR
 import com.zion830.threedollars.core.designsystem.R as DesignSystemR
+
+private const val FOCUS_BOUNDS_PADDING_DP = 24f
 
 @AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
@@ -427,6 +430,11 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
                     }
                 }
                 launch {
+                    viewModel.focusBounds.collect { bounds ->
+                        moveMapToFocusBounds(bounds)
+                    }
+                }
+                launch {
                     searchViewModel.searchResultLocation.collect {
                         naverMapFragment.moveCamera(it)
                         binding.tvAddress.text =
@@ -440,6 +448,20 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>() {
                 }
             }
         }
+    }
+
+    private fun moveMapToFocusBounds(bounds: SDLocationBoundsModel) {
+        val basePaddingPx = SizeUtils.dpToPx(FOCUS_BOUNDS_PADDING_DP)
+        naverMapFragment.moveCameraToBounds(
+            southWest = LatLng(bounds.southWest.latitude, bounds.southWest.longitude),
+            northEast = LatLng(bounds.northEast.latitude, bounds.northEast.longitude),
+            paddingPx = intArrayOf(
+                basePaddingPx,
+                binding.filterComposeView.bottom + basePaddingPx,
+                basePaddingPx,
+                SizeUtils.dpToPx(HomeSheetLayout.COLLAPSED_PEEK_HEIGHT_DP) + basePaddingPx,
+            ),
+        )
     }
 
     private fun handleFilterDeepLink(link: SDLinkModel) {

--- a/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/home/viewModel/HomeViewModel.kt
@@ -24,6 +24,7 @@ import com.threedollar.common.serverdriven.model.SDClickLogModel
 import com.threedollar.common.serverdriven.model.SDImageModel
 import com.threedollar.common.serverdriven.model.SDImageStyleModel
 import com.threedollar.common.serverdriven.model.SDLinkModel
+import com.threedollar.common.serverdriven.model.SDLocationBoundsModel
 import com.threedollar.common.serverdriven.model.SDSurfaceStyleModel
 import com.threedollar.common.serverdriven.model.SDTextModel
 import com.threedollar.common.serverdriven.model.StoreActionBarModel
@@ -89,6 +90,9 @@ class HomeViewModel @Inject constructor(
     private val _filterDeepLink = MutableSharedFlow<SDLinkModel>(extraBufferCapacity = 1)
     val filterDeepLink: SharedFlow<SDLinkModel> = _filterDeepLink.asSharedFlow()
 
+    private val _focusBounds = MutableSharedFlow<SDLocationBoundsModel>(extraBufferCapacity = 1)
+    val focusBounds: SharedFlow<SDLocationBoundsModel> = _focusBounds.asSharedFlow()
+
     private val _homeListSection = MutableStateFlow(HomeListSectionModel())
     val homeListSection: StateFlow<HomeListSectionModel> = _homeListSection.asStateFlow()
 
@@ -107,6 +111,10 @@ class HomeViewModel @Inject constructor(
     val selectedHomeListCardId: StateFlow<String?> = _selectedHomeListCardId.asStateFlow()
 
     private var homeListNextCursor: String? = null
+
+    private var preset: String? = null
+
+    private var hasRequestedHomeList = false
     private var isHomeListLoading = false
 
     private var shouldResetScroll = false
@@ -205,6 +213,7 @@ class HomeViewModel @Inject constructor(
     ) {
         viewModelScope.launch(coroutineExceptionHandler) {
             isHomeListLoading = true
+            hasRequestedHomeList = true
             val previousSelectedCardId = _selectedHomeListCardId.value
             val previousSelectedStoreId = _selectedStorePreviewStoreId.value
             val params = HomeAroundStoreRequestParamsBuilder.build(
@@ -235,6 +244,7 @@ class HomeViewModel @Inject constructor(
                     _homeListSection.value = section.copy(cards = nextCards)
                     homeListNextCursor = section.cursor?.nextCursor?.takeIf { section.cursor?.hasMore == true }
                     if (!append) {
+                        section.focusBounds?.let { _focusBounds.tryEmit(it) }
                         val cards = section.cards.filterIsInstance<HomeListCardModel.BasicCard>()
                         val selectedCardId = if (preserveSelectedStore) {
                             cards.selectedCardIdAfterRefresh(
@@ -492,9 +502,16 @@ class HomeViewModel @Inject constructor(
 
     // ----- SDU filter -----
 
-    private fun fetchHomeFilterScreen() {
+    fun applyPreset(preset: String) {
+        this.preset = preset
+        fetchHomeFilterScreen(shouldRefreshCards = true)
+    }
+
+    private fun fetchHomeFilterScreen(shouldRefreshCards: Boolean = false) {
+        val requestedPreset = preset
         viewModelScope.launch(coroutineExceptionHandler) {
-            screenRepository.getHomeFilterScreen().collect { response ->
+            screenRepository.getHomeFilterScreen(preset = requestedPreset).collect { response ->
+                if (requestedPreset != preset) return@collect
                 if (response.ok && response.data != null) {
                     val screen = response.data!!
                     _uiState.update {
@@ -504,8 +521,12 @@ class HomeViewModel @Inject constructor(
                         )
                     }
                     _initialMapZoomLevel.value = screen.configuration?.initialMapZoomLevel
-                    initializeRadioSelectionDefaults()
+                    applyServerSelectionDefaults()
                     updateFilterCells()
+
+                    if (shouldRefreshCards && hasRequestedHomeList) {
+                        fetchAroundStores()
+                    }
                 } else {
                     _filterCells.value = makeFallbackFilterCells(uiState.value.selectedCategory)
                 }
@@ -547,10 +568,10 @@ class HomeViewModel @Inject constructor(
         return serverBars.ifEmpty { fallbackBars() }
     }
 
-    private fun initializeRadioSelectionDefaults() {
-        val newSelection = uiState.value.radioSelection.toMutableMap()
+    private fun applyServerSelectionDefaults() {
+        val newSelection = mutableMapOf<String, Int>()
         for (bar in allBars()) {
-            if (bar is HomeFilterBar.RadioBar && newSelection[bar.paramKey] == null) {
+            if (bar is HomeFilterBar.RadioBar) {
                 newSelection[bar.paramKey] = 0
             }
         }

--- a/app/src/main/java/com/zion830/threedollars/ui/map/ui/NaverMapFragment.kt
+++ b/app/src/main/java/com/zion830/threedollars/ui/map/ui/NaverMapFragment.kt
@@ -33,6 +33,7 @@ import com.google.android.gms.tasks.CancellationTokenSource
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.logEvent
 import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
 import com.naver.maps.map.CameraAnimation
 import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.LocationTrackingMode
@@ -588,6 +589,23 @@ open class NaverMapFragment : Fragment(R.layout.fragment_naver_map), OnMapReadyC
 
         isInitialCameraPlaced = true
         naverMap?.moveCamera(cameraUpdateForMove(position).animate(CameraAnimation.Easing))
+    }
+
+    fun moveCameraToBounds(
+        southWest: LatLng,
+        northEast: LatLng,
+        paddingPx: IntArray,
+    ) {
+        if (naverMap == null || paddingPx.size != 4) {
+            return
+        }
+
+        isInitialCameraPlaced = true
+        val bounds = LatLngBounds(southWest, northEast)
+        val cameraUpdate = CameraUpdate
+            .fitBounds(bounds, paddingPx[0], paddingPx[1], paddingPx[2], paddingPx[3])
+            .animate(CameraAnimation.Easing)
+        naverMap?.moveCamera(cameraUpdate)
     }
 
     private fun cameraUpdateForMove(position: LatLng): CameraUpdate {

--- a/core/common/src/main/java/com/threedollar/common/serverdriven/model/ServerDrivenModels.kt
+++ b/core/common/src/main/java/com/threedollar/common/serverdriven/model/ServerDrivenModels.kt
@@ -160,9 +160,15 @@ data class SDLocationModel(
     val longitude: Double,
 )
 
+data class SDLocationBoundsModel(
+    val southWest: SDLocationModel,
+    val northEast: SDLocationModel,
+)
+
 data class HomeListSectionModel(
     val cards: List<HomeListCardModel> = emptyList(),
     val cursor: SDCursorModel? = null,
+    val focusBounds: SDLocationBoundsModel? = null,
 )
 
 sealed interface HomeListCardModel {

--- a/core/network/src/main/java/com/threedollar/network/api/ServerApi.kt
+++ b/core/network/src/main/java/com/threedollar/network/api/ServerApi.kt
@@ -214,7 +214,9 @@ interface ServerApi {
     ): Response<BaseResponse<UserStoreResponse>>
 
     @GET("/api/v1/screen/home")
-    suspend fun getHomeFilterScreen(): Response<BaseResponse<HomeFilterScreenResponse>>
+    suspend fun getHomeFilterScreen(
+        @Query("preset") preset: String? = null,
+    ): Response<BaseResponse<HomeFilterScreenResponse>>
 
     @GET("/api/v1/screen/home/section/list")
     suspend fun getHomeListSection(

--- a/core/network/src/main/java/com/threedollar/network/data/screen/HomeBottomSheetScreenResponse.kt
+++ b/core/network/src/main/java/com/threedollar/network/data/screen/HomeBottomSheetScreenResponse.kt
@@ -9,6 +9,15 @@ data class HomeListSectionResponse(
     val cards: List<HomeListCardResponse>? = emptyList(),
     @SerializedName("cursor")
     val cursor: SDCursorResponse? = null,
+    @SerializedName("focusBounds")
+    val focusBounds: SDLocationBoundsResponse? = null,
+)
+
+data class SDLocationBoundsResponse(
+    @SerializedName("southWest")
+    val southWest: SDLocationResponse? = null,
+    @SerializedName("northEast")
+    val northEast: SDLocationResponse? = null,
 )
 
 data class HomeListCardResponse(

--- a/data/src/main/java/com/threedollar/data/screen/HomeBottomSheetScreenMapper.kt
+++ b/data/src/main/java/com/threedollar/data/screen/HomeBottomSheetScreenMapper.kt
@@ -17,6 +17,7 @@ import com.threedollar.common.serverdriven.model.SDImageModel
 import com.threedollar.common.serverdriven.model.SDImageStyleModel
 import com.threedollar.common.serverdriven.model.SDImpressionLogModel
 import com.threedollar.common.serverdriven.model.SDLinkModel
+import com.threedollar.common.serverdriven.model.SDLocationBoundsModel
 import com.threedollar.common.serverdriven.model.SDLocationModel
 import com.threedollar.common.serverdriven.model.SDSurfaceStyleModel
 import com.threedollar.common.serverdriven.model.SDTextModel
@@ -40,6 +41,7 @@ import com.threedollar.network.data.screen.SDImageResponse
 import com.threedollar.network.data.screen.SDImageStyleResponse
 import com.threedollar.network.data.screen.SDImpressionLogResponse
 import com.threedollar.network.data.screen.SDLinkResponse
+import com.threedollar.network.data.screen.SDLocationBoundsResponse
 import com.threedollar.network.data.screen.SDLocationResponse
 import com.threedollar.network.data.screen.SDPageViewLogResponse
 import com.threedollar.network.data.screen.SDSurfaceStyleResponse
@@ -52,7 +54,17 @@ import com.threedollar.network.data.screen.StoreSectionResponse
 fun HomeListSectionResponse.asModel(): HomeListSectionModel = HomeListSectionModel(
     cards = cards.orEmpty().mapNotNull { it.asHomeListCardModelOrNull() },
     cursor = cursor?.asModel(),
+    focusBounds = focusBounds?.asModelOrNull(),
 )
+
+private fun SDLocationBoundsResponse.asModelOrNull(): SDLocationBoundsModel? {
+    val southWestModel = southWest?.asModelOrNull() ?: return null
+    val northEastModel = northEast?.asModelOrNull() ?: return null
+    return SDLocationBoundsModel(
+        southWest = southWestModel,
+        northEast = northEastModel,
+    )
+}
 
 fun StoreScreenResponse.asModel(): StoreScreenModel = StoreScreenModel(
     sections = sections.orEmpty().mapNotNull { it.asStoreSectionModelOrNull() },

--- a/data/src/main/java/com/threedollar/data/screen/datasource/ScreenRemoteDataSource.kt
+++ b/data/src/main/java/com/threedollar/data/screen/datasource/ScreenRemoteDataSource.kt
@@ -27,5 +27,5 @@ interface ScreenRemoteDataSource {
         cursor: String?,
     ): Flow<BaseResponse<StoreContributorHistoriesResponse>>
 
-    fun getHomeFilterScreen(): Flow<BaseResponse<HomeFilterScreenResponse>>
+    fun getHomeFilterScreen(preset: String? = null): Flow<BaseResponse<HomeFilterScreenResponse>>
 }

--- a/data/src/main/java/com/threedollar/data/screen/datasource/ScreenRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/threedollar/data/screen/datasource/ScreenRemoteDataSourceImpl.kt
@@ -53,7 +53,7 @@ class ScreenRemoteDataSourceImpl @Inject constructor(
         emit(apiResult(serverApi.getStoreContributorHistories(storeId, cursor)))
     }
 
-    override fun getHomeFilterScreen(): Flow<BaseResponse<HomeFilterScreenResponse>> = flow {
-        emit(apiResult(serverApi.getHomeFilterScreen()))
+    override fun getHomeFilterScreen(preset: String?): Flow<BaseResponse<HomeFilterScreenResponse>> = flow {
+        emit(apiResult(serverApi.getHomeFilterScreen(preset = preset)))
     }
 }

--- a/data/src/main/java/com/threedollar/data/screen/repository/ScreenRepositoryImpl.kt
+++ b/data/src/main/java/com/threedollar/data/screen/repository/ScreenRepositoryImpl.kt
@@ -73,8 +73,8 @@ class ScreenRepositoryImpl @Inject constructor(
             )
         }
 
-    override fun getHomeFilterScreen(): Flow<BaseResponse<HomeFilterScreenModel>> =
-        screenRemoteDataSource.getHomeFilterScreen().map {
+    override fun getHomeFilterScreen(preset: String?): Flow<BaseResponse<HomeFilterScreenModel>> =
+        screenRemoteDataSource.getHomeFilterScreen(preset = preset).map {
             BaseResponse(
                 ok = it.ok,
                 data = it.data?.asModel() ?: HomeFilterScreenModel(),

--- a/domain/src/main/java/com/threedollar/domain/screen/repository/ScreenRepository.kt
+++ b/domain/src/main/java/com/threedollar/domain/screen/repository/ScreenRepository.kt
@@ -27,5 +27,5 @@ interface ScreenRepository {
         cursor: String?,
     ): Flow<BaseResponse<SDSectionModel.CardsSection>>
 
-    fun getHomeFilterScreen(): Flow<BaseResponse<HomeFilterScreenModel>>
+    fun getHomeFilterScreen(preset: String? = null): Flow<BaseResponse<HomeFilterScreenModel>>
 }


### PR DESCRIPTION
## 변경 사항

[TH-1262](https://3dollarinmypocket.atlassian.net/browse/TH-1262) — iOS [PR #318](https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-ios/pull/318)과 동일 스펙

- 홈 딥링크(`/home?preset=...`)와 preset 필터 진입 시 `preset`을 홈 필터 스크린 API에 전달하고, 서버가 내려준 선택 상태로 필터를 리셋한 뒤 카드를 재조회합니다.
- 홈 리스트 첫 페이지 응답에 `focusBounds`가 있으면 지도 카메라를 해당 범위에 맞춰 이동합니다(상단 필터 바·하단 바텀시트 가시 영역 패딩 적용).
- preset 적용 중 이전 필터 스크린 응답이 늦게 도착하면 버리도록 가드를 추가했습니다.

## 검증

- `dollars-dev://home?preset=mim_pd` 딥링크 확인
- https://app.dev.threedollars.co.kr/home?preset=mim_pd
- `:app` 컴파일 통과

[TH-1262]: https://3dollarinmypocket.atlassian.net/browse/TH-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ